### PR TITLE
feat: add round up number pipe

### DIFF
--- a/angular-apollo-tailwind/projects/shared/src/lib/components/count-button-group/count-button-group.component.html
+++ b/angular-apollo-tailwind/projects/shared/src/lib/components/count-button-group/count-button-group.component.html
@@ -9,6 +9,6 @@
     type="button"
     class="-ml-px relative inline-flex items-center px-3 py-1.5 rounded-r-md border border-gray-300 bg-white text-xs font-semibold text-gray-700 hover:text-blue-600"
   >
-    {{ count }}
+    {{ count | roundUp }}
   </button>
 </span>

--- a/angular-apollo-tailwind/projects/shared/src/lib/components/count-button-group/count-button-group.module.ts
+++ b/angular-apollo-tailwind/projects/shared/src/lib/components/count-button-group/count-button-group.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CountButtonGroupComponent } from './count-button-group.component';
+import { PipesModule } from '../../';
 
 @NgModule({
   declarations: [CountButtonGroupComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, PipesModule],
   exports: [CountButtonGroupComponent],
 })
 export class CountButtonGroupComponentModule {}

--- a/angular-apollo-tailwind/projects/shared/src/lib/pipes/index.ts
+++ b/angular-apollo-tailwind/projects/shared/src/lib/pipes/index.ts
@@ -1,2 +1,3 @@
 export * from './dfns/format-distance.pipe';
+export * from './number/round-up.pipe';
 export * from './pipes.module';

--- a/angular-apollo-tailwind/projects/shared/src/lib/pipes/number/round-up.pipe.spec.ts
+++ b/angular-apollo-tailwind/projects/shared/src/lib/pipes/number/round-up.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { RoundUpPipe } from './round-up.pipe';
+
+describe('RoundUpPipe', () => {
+  it('create an instance', () => {
+    const pipe = new RoundUpPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/angular-apollo-tailwind/projects/shared/src/lib/pipes/number/round-up.pipe.ts
+++ b/angular-apollo-tailwind/projects/shared/src/lib/pipes/number/round-up.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'roundUp',
+})
+export class RoundUpPipe implements PipeTransform {
+  transform(count: number): string {
+    let countText = `${count}`;
+    if (count && count > 1000) {
+      const digits = countText.split('');
+      digits.splice(digits.length - 3, 3);
+      countText = `${digits.join('')}k`;
+    }
+    return countText;
+  }
+}

--- a/angular-apollo-tailwind/projects/shared/src/lib/pipes/pipes.module.ts
+++ b/angular-apollo-tailwind/projects/shared/src/lib/pipes/pipes.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
-import { FormatDistancePipe } from './dfns/format-distance.pipe';
+import { FormatDistancePipe, RoundUpPipe } from './';
 
 @NgModule({
-  declarations: [FormatDistancePipe],
-  exports: [FormatDistancePipe],
+  declarations: [FormatDistancePipe, RoundUpPipe],
+  exports: [FormatDistancePipe, RoundUpPipe],
 })
 export class PipesModule {}


### PR DESCRIPTION
# Overivew

Adds a number pipe to round up numbers over 1000 in the repo page's header.

![image](https://user-images.githubusercontent.com/9042219/147700768-26421eab-6f9a-4a1b-93f5-a931d61d6c4b.png)
