### PR TITLE
fix gist links

### DIFF
--- a/angular-apollo-tailwind/src/app/repos/components/user-gists/user-gists.component.html
+++ b/angular-apollo-tailwind/src/app/repos/components/user-gists/user-gists.component.html
@@ -3,7 +3,7 @@
     <ng-container *ngIf="!details.error; else error">
       <div class="mt-3">
         <div class="my-1" *ngFor="let gist of details.gists">
-          <a [href]="[gist.url]" class="link" target="_blank">
+          <a [href]="gist.url" class="link" target="_blank">
             {{ gist?.files?.[0]?.name || gist?.name }}
           </a>
         </div>


### PR DESCRIPTION
`routerLink` tries to point to a relative site URL but these links are fully qualified external URLs.