### PR TITLE
[Angular - NgRx - SCSS] Fix Flaky Auth Karma Tests

### DIFF
--- a/angular-ngrx-scss/src/app/auth/services/auth.service.spec.ts
+++ b/angular-ngrx-scss/src/app/auth/services/auth.service.spec.ts
@@ -40,6 +40,7 @@ describe('AuthService', () => {
     tokenService = TestBed.inject(TokenService);
     authService = TestBed.inject(AuthService);
     httpController = TestBed.inject(HttpTestingController);
+    token = 'hello';
   });
 
   it('should redirect the user to the sign in link', () => {


### PR DESCRIPTION
Tests for the auth service were flaky because one of the tests was mutating global state, but tests are not guaranteed to always run in-order as they are defined (this is determined by the seed). I reset the token value in auth.service.spec.ts so it's reset before each test is run to avoid the flakiness.