### PR TITLE
changed env url

### DIFF
--- a/angular-apollo-tailwind/.env.example
+++ b/angular-apollo-tailwind/.env.example
@@ -1,4 +1,4 @@
 GITHUB_GRAPHQL_URL=https://api.github.com/graphql
-OAUTH_API_URL=/api
+OAUTH_API_URL=
 CLIENT_REDIRECT_URL=https://localhost:4200/redirect
 PRODUCTION=false

--- a/angular-apollo-tailwind/src/app/auth/auth.service.ts
+++ b/angular-apollo-tailwind/src/app/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
    */
   signin(): void {
     this.tokenService.removeToken();
-    window.location.href = `${environment.apiUrl}/auth/signin?redirect_url=${environment.redirectUrl}`;
+    window.location.href = `${environment.apiUrl}/api/auth/signin?redirect_url=${environment.redirectUrl}`;
   }
 
   /**
@@ -41,7 +41,7 @@ export class AuthService {
    */
   getToken(): Observable<string | undefined> {
     return this.httpClient
-      .get<AuthResponse>(`${environment.apiUrl}/auth/token`, {
+      .get<AuthResponse>(`${environment.apiUrl}/api/auth/token`, {
         withCredentials: true,
       })
       .pipe(
@@ -59,7 +59,7 @@ export class AuthService {
   signout(): Observable<SignoutRepsonse> {
     this.tokenService.removeToken();
     return this.httpClient.post<SignoutRepsonse>(
-      `${environment.apiUrl}/auth/signout`,
+      `${environment.apiUrl}/api/auth/signout`,
       null,
     );
   }

--- a/angular-apollo-tailwind/src/environments/environment.ts
+++ b/angular-apollo-tailwind/src/environments/environment.ts
@@ -12,7 +12,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: '/api',
+  apiUrl: '',
   graphApiUrl: 'https://api.github.com/graphql',
   redirectUrl: 'https://localhost:4200/redirect',
 };

--- a/starter-dev-backend/package.json
+++ b/starter-dev-backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "sls offline"
+    "start": "sls offline",
+    "deploy": "sls deploy --stage production --region us-east-1"
   },
   "dependencies": {
     "@types/cookie-parser": "^1.4.2",

--- a/starter-dev-backend/serverless.yml
+++ b/starter-dev-backend/serverless.yml
@@ -8,20 +8,19 @@ plugins:
   - serverless-offline
 
 custom:
-  serverless-offline:
-    httpPort: 4000
-  customDomain:
+  customDomain: # serverless-domain-manager
     domainName: api.starter.dev
     stage: production
     endpointType: 'regional'
     apiType: http
     certificateName: '*.starter.dev'
 
+  serverless-offline: # serverless-offline
+    httpPort: 4000
+
 provider:
   name: aws
   profile: starterdev
-  stage: ${sls:stage}
-  region: ${aws:region}
   runtime: nodejs14.x
 
 functions:


### PR DESCRIPTION
Removed the need to specify a `/api` path at the end of a server endpoint.

Local dev:
* still proxies `/api` by default

Prod:
* will append the baseUrl to a `/api` path.