### PR TITLE
[CRA-RXJS-SC] Fix redirect loop on login

### DIFF
--- a/cra-rxjs-styled-components/src/constants/url.constants.ts
+++ b/cra-rxjs-styled-components/src/constants/url.constants.ts
@@ -11,6 +11,7 @@ export const SIGN_IN_BASE_URL = `${API_URL_BASE}/auth/signin`;
 export const SIGN_IN_URL = (() => {
 	const url = new URL(SIGN_IN_BASE_URL);
 	url.searchParams.set('redirect_url', REDIRECT_URL);
+	console.log(url.toString());
 	return url.toString();
 })();
 

--- a/cra-rxjs-styled-components/src/hooks/auth/use-set-token.ts
+++ b/cra-rxjs-styled-components/src/hooks/auth/use-set-token.ts
@@ -16,7 +16,11 @@ export function useSetToken() {
 				'Content-Type': 'application/json; charset=UTF-8',
 			}),
 			credentials: 'include',
-			selector: (response: Response) => response.json(),
+			selector: (response: Response) => {
+				const t = response.json();
+				console.log(t); // empty object on non-chromium browser (e.g Firefox)
+				return t;
+			},
 		})
 			.pipe(
 				tap(({ access_token }) => {
@@ -24,7 +28,8 @@ export function useSetToken() {
 						throw new Error(`Error: could not retrieve token`);
 					}
 				}),
-				catchError(() => {
+				catchError((e) => {
+					alert(e);
 					navigate('/signin', { replace: true });
 					return EMPTY;
 				})


### PR DESCRIPTION
Should close #540 

May need access to `api.starter.dev` code to debug, as the endpoint doesn't return the `access_token` on non chromium browsers (like Firefox). 
