### PR TITLE
[CRA RXJS SC] fix broken link

### DIFF
--- a/cra-rxjs-styled-components/README.md
+++ b/cra-rxjs-styled-components/README.md
@@ -4,16 +4,18 @@ This is a demo application that re-implements some of GitHub's pages and functio
 
 ## Table of Contents
 
-- [Overview](#overview)
-  - [Featured Tech Stack](#featured-tech-stack)
-  - [Included Tooling](#included-tooling)
-- [Architectural Decisions](#architectural-decisions)
-- [Getting Started](#getting-started)
-  - [Cloning the Repository](#cloning-the-repository)
-  - [Env Setup](#env-setup)
-  - [0Auth Setup](#oauth-setup)
-  - [Installation](#installation)
-- [Development](#development)
+- [CRA-RxJS-SC App](#cra-rxjs-sc-app)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Featured Tech Stack](#featured-tech-stack)
+    - [Included Tooling](#included-tooling)
+  - [Architectural Decisions](#architectural-decisions)
+  - [Getting Started](#getting-started)
+    - [Cloning the Repository](#cloning-the-repository)
+    - [Env Setup](#env-setup)
+    - [OAuth Setup](#oauth-setup)
+    - [Installation](#installation)
+  - [Development](#development)
 
 ## Overview
 
@@ -43,10 +45,10 @@ This is a demo application that re-implements some of GitHub's pages and functio
 
 ### Cloning the Repository
 
-Clone the starter.dev-showcases repository from https://github.com/thisdot/starter.dev-showcases
+Clone the starter.dev-showcases repository from https://github.com/thisdot/starter.dev-github-showcases
 
 ```bash
-git clone https://github.com/thisdot/starter.dev-showcases.git
+git clone https://github.com/thisdot/starter.dev-github-showcases
 ```
 
 ### Env Setup

--- a/cra-rxjs-styled-components/README.md
+++ b/cra-rxjs-styled-components/README.md
@@ -48,7 +48,7 @@ This is a demo application that re-implements some of GitHub's pages and functio
 Clone the starter.dev-showcases repository from https://github.com/thisdot/starter.dev-github-showcases
 
 ```bash
-git clone https://github.com/thisdot/starter.dev-github-showcases
+git clone https://github.com/thisdot/starter.dev-github-showcases.git
 ```
 
 ### Env Setup


### PR DESCRIPTION
Fixes broken link to the showcases Github repo in the README.

closes #594 