### PR TITLE
[Angular-Apollo-Tailwind] Add 404 page

### DIFF
--- a/angular-apollo-tailwind/src/app/app-routing.module.ts
+++ b/angular-apollo-tailwind/src/app/app-routing.module.ts
@@ -16,6 +16,12 @@ const routes: Routes = [
     path: '',
     loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
   },
+  //Wild Card Route for 404 request
+  // {
+  //   path: '**',
+  //   pathMatch: 'full',
+  //   component: PagenotfoundComponent,
+  // },
 ];
 
 @NgModule({

--- a/angular-apollo-tailwind/src/app/app-routing.module.ts
+++ b/angular-apollo-tailwind/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { RouteConfigModule } from '@this-dot/route-config';
+import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 
 const routes: Routes = [
   {
@@ -17,11 +18,11 @@ const routes: Routes = [
     loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
   },
   //Wild Card Route for 404 request
-  // {
-  //   path: '**',
-  //   pathMatch: 'full',
-  //   component: PagenotfoundComponent,
-  // },
+  {
+    path: '**',
+    pathMatch: 'full',
+    component: PageNotFoundComponent,
+  },
 ];
 
 @NgModule({

--- a/angular-apollo-tailwind/src/app/app.module.ts
+++ b/angular-apollo-tailwind/src/app/app.module.ts
@@ -8,9 +8,10 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { GraphQLModule } from './gql/graphql.module';
 import { TokenInterceptor } from './auth/token.interceptor';
+import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, PageNotFoundComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,

--- a/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.css
+++ b/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.css
@@ -1,0 +1,7 @@
+.container {
+  @apply flex items-center justify-center my-8;
+}
+
+.title {
+  @apply text-lg;
+}

--- a/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.html
+++ b/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  <h1 class="title">404</h1>
+</div>

--- a/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.spec.ts
+++ b/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageNotFoundComponent } from './page-not-found.component';
+
+describe('PageNotFoundComponent', () => {
+  let component: PageNotFoundComponent;
+  let fixture: ComponentFixture<PageNotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PageNotFoundComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PageNotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.ts
+++ b/angular-apollo-tailwind/src/app/components/page-not-found/page-not-found.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  templateUrl: './page-not-found.component.html',
+  styleUrls: ['./page-not-found.component.css'],
+})
+export class PageNotFoundComponent {}


### PR DESCRIPTION
Resolvees: #607 
Currently navigating to a page that doesn't have any data will try loading eg. a user, and display a graphql error.

# Acceptance
- Navigating to a page that doesn't have any data should show 404 page.
