### PR TITLE
Dev server Update CORS to allow 127.0.0.1

### DIFF
--- a/starter-dev-backend/handler.js
+++ b/starter-dev-backend/handler.js
@@ -18,6 +18,7 @@ app.use(
     origin: new RegExp(
       [
         'localhost',
+        '127.0.0.1',
         process.env.SERVER_BASE_URL,
         process.env.CORS_REGEXP,
         process.env.PR_PREVIEW_REGEXP,


### PR DESCRIPTION
Extends CORS policy to allow origin 127.0.0.1 (localhost alias)

Case covered: sveltekit app created with CLI and running locally on dev machine has default url:
![image](https://user-images.githubusercontent.com/31627738/196913428-54879342-a4b1-4e11-ade2-b417347d66bd.png)
