### PR TITLE
feat: [sveltekit-pod] make token available in PageServerLoad

### DIFF
--- a/svelte-kit-scss/src/hooks.server.ts
+++ b/svelte-kit-scss/src/hooks.server.ts
@@ -4,8 +4,19 @@ import {
 } from '$lib/constants/auth';
 import type { Handle } from '@sveltejs/kit';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace App {
+    interface Locals {
+      accessToken?: string;
+    }
+  }
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
   const accessTokenFromCookies = event.cookies.get(AUTH_COOKIE_NAME);
+
+  event.locals.accessToken = accessTokenFromCookies;
 
   if (!accessTokenFromCookies) {
     if (!event.url.pathname.startsWith('/signin')) {
@@ -16,6 +27,7 @@ export const handle: Handle = async ({ event, resolve }) => {
   // erase token cookie
   if (event.url.pathname === '/signin') {
     event.cookies.set(AUTH_COOKIE_NAME, String(), AUTH_COOKIE_ERASE_OPTIONS);
+    event.locals.accessToken = undefined;
   }
 
   const response = await resolve(event);


### PR DESCRIPTION
resolves #666 

Improvment: make the token available in PageServerLoad

Now the token available in `PageServerLoad`:
```
export const load: PageServerLoad = async ({locals}) => {
...
const token = locals.accessToken
...
```