### PR TITLE
in progress

### DIFF
--- a/qwik-graphql-tailwind/src/utils/queries/issues-query.ts
+++ b/qwik-graphql-tailwind/src/utils/queries/issues-query.ts
@@ -1,0 +1,51 @@
+export const ISSUES_QUERY = `
+  query IssuesQuery($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      openIssues: issues(
+        first: $first
+        states: [OPEN]
+        orderBy: { field: CREATED_AT, direction: DESC }
+      ) {
+        edges {
+          node {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+          }
+        }
+      }
+
+      closedIssues: issues(
+        first: $first
+        states: [CLOSED]
+        orderBy: { field: CREATED_AT, direction: DESC }
+      ) {
+        edges {
+          node {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Get issue information from GitHub API

## Background

On the single repo page, we’ll have a tab for viewing open and closed issues. We do not (currently) have the functionality to click into the issues, so this ticket will be for creating the initial view that mostly concerns the name of the issue and some metadata about each one.

## Acceptance

- [x] Get repository issues from GitHub API
- [x] For display in issues tab on single repository page; data needed:
    - [x] name of issue
    - [x] issue number
    - [x] name of person who created the issue
    - [x] created / closed date
    - [x] number of comments

## Notes

