### PR TITLE
feat(qwik-pod): Add org profile layout

### DIFF
--- a/qwik-graphql-tailwind/src/components/icons/repo.icon.tsx
+++ b/qwik-graphql-tailwind/src/components/icons/repo.icon.tsx
@@ -1,0 +1,14 @@
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
+import { iconStyles } from './icons.styles';
+import { IconProps } from './types';
+
+// Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc.
+export const RepoIcon = component$(({ className }: IconProps) => {
+  useStylesScoped$(iconStyles);
+  return (
+    <svg viewBox="0 0 24 24" version="1.1" className={className ?? ''} >
+      <path fill="none" d="M0 0h24v24H0z" />
+      <path d="M13 21v2.5l-3-2-3 2V21h-.5A3.5 3.5 0 0 1 3 17.5V5a3 3 0 0 1 3-3h14a1 1 0 0 1 1 1v17a1 1 0 0 1-1 1h-7zm0-2h6v-3H6.5a1.5 1.5 0 0 0 0 3H7v-2h6v2zm6-5V4H6v10.035A3.53 3.53 0 0 1 6.5 14H19zM7 5h2v2H7V5zm0 3h2v2H7V8zm0 3h2v2H7v-2z" />
+    </svg>
+  );
+});

--- a/qwik-graphql-tailwind/src/routes/orgs/[name]/index.tsx
+++ b/qwik-graphql-tailwind/src/routes/orgs/[name]/index.tsx
@@ -1,0 +1,17 @@
+import { component$, useClientEffect$ } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
+import { OrgProfileCard } from './org-profile-card';
+
+export default component$(() => {
+  useClientEffect$(async () => {
+    // const abortController = new AbortController();
+    // const response = await fetchUserProfile(location.params.user, abortController);
+    //updateUserProfile(store, response);
+  });
+
+  return (
+    <div>
+      <OrgProfileCard />
+    </div>
+  );
+});

--- a/qwik-graphql-tailwind/src/routes/orgs/[name]/org-profile-card.tsx
+++ b/qwik-graphql-tailwind/src/routes/orgs/[name]/org-profile-card.tsx
@@ -1,0 +1,39 @@
+import { component$ } from '@builder.io/qwik';
+import { RepoIcon } from '~/components/icons/repo.icon';
+
+export const OrgProfileCard = component$(() => {
+  return (
+    <div className="relative pt-8 bg-gray-50">
+      <div className="border-b border-gray-200 pt-2 ">
+        <div className="grid grid-cols-12 max-w-screen-lg mx-auto">
+          <div className="col-span-12 md:col-span-8 xl:col-span-12 px-4">
+            <a className="text-black">
+              <h1 className="flex text-2xl font-bold">
+                <img
+                  className="mr-1"
+                  width="30"
+                  height="30"
+                  src="https://avatars.githubusercontent.com/u/22839396?v=4"
+                />
+                This Dot
+              </h1>
+            </a>
+          </div>
+          <div className="col-span-12 md:col-span-8 xl:col-span-12">
+            <div className="px-4">
+              <nav className="flex" aria-label="Tabs">
+                <div className="p-4 text-sm border-b-2 border-yellow-500">
+                  <a>
+                    <RepoIcon className="w-6 h-6 text-gray-600" />
+                    <span className="text-black font-semibold">Repositories</span>
+                  </a>
+                </div>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="max-w-screen-lg mx-auto py-8 px-4">There will be repos soon.</div>
+    </div>
+  );
+});

--- a/qwik-graphql-tailwind/src/routes/orgs/[name]/types.ts
+++ b/qwik-graphql-tailwind/src/routes/orgs/[name]/types.ts
@@ -1,0 +1,4 @@
+export interface Organization {
+  avatarUrl: string;
+  name: string;
+}


### PR DESCRIPTION
## Acceptance Criteria

- [x]  1 column layout
- [x]  sub-header spanning both columns, showing book icon and repositories title - should be sticky on scroll
- [x]  Top of main section - search / filter / sort component
- [x]  Main section - card for all org repos

Fixes: #786 