### PR TITLE
[sveltekit-pod] 18 Create profile page layout

### DIFF
--- a/svelte-kit-scss/package-lock.json
+++ b/svelte-kit-scss/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-storybook": "0.6.6",
         "eslint-plugin-svelte3": "4.0.0",
+        "husky": "^8.0.1",
         "jsdom": "20.0.1",
         "prettier": "2.7.1",
         "prettier-plugin-svelte": "2.8.0",
@@ -15554,6 +15555,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -36787,6 +36803,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/svelte-kit-scss/src/lib/components/Profile/OrgInfo/OrgInfo.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/OrgInfo/OrgInfo.svelte
@@ -1,0 +1,9 @@
+<div class="org-info-container">
+    <a href="/thisdot">
+      <img
+        src="https://avatars.githubusercontent.com/u/22839396?v=4"
+        alt="thisdot logo"
+      />
+      <span class="title">This Dot</span>
+    </a>
+  </div>

--- a/svelte-kit-scss/src/lib/components/Profile/OrgInfo/OrgInfo.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/OrgInfo/OrgInfo.svelte
@@ -1,9 +1,35 @@
-<div class="org-info-container">
-    <a href="/thisdot">
-      <img
-        src="https://avatars.githubusercontent.com/u/22839396?v=4"
-        alt="thisdot logo"
-      />
-      <span class="title">This Dot</span>
-    </a>
-  </div>
+<div class="org-info-container col-span-12">
+  <a href="/thisdot">
+    <img
+      src="https://avatars.githubusercontent.com/u/22839396?v=4"
+      alt="thisdot logo"
+    />
+    <span class="title">This Dot</span>
+  </a>
+</div>
+
+<style lang="scss">
+  .org-info-container {
+    a {
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+      color: inherit;
+      .title {
+        font-weight: 700;
+        font-size: 1.5rem;
+        line-height: 2rem;
+      }
+      img {
+        display: block;
+        width: 32px;
+        height: 32px;
+        margin-right: 0.25rem;
+        aspect-ratio: 1/1;
+        border-radius: 0.25rem;
+        box-sizing: content-box;
+        background-color: white;
+      }
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.spec.ts
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.spec.ts
@@ -1,11 +1,11 @@
 import { beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ProfileAboutSection from './ProfileAboutSection.svelte';
-import { userInfoFixture, userOrgs } from '../../fixtures/user';
+import { userInfoFixture, userOrgs } from '$lib/fixtures/user';
 import {
   mapUserInfoResponseToUserInfo,
   mapUserOrgsApiResponseToUserOrgs,
-} from '../../helpers/user';
+} from '$lib/helpers/user';
 
 describe('ProfileAboutSection', () => {
   beforeEach(() => {

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { UserInfo, UserOrgs } from '../../../interfaces';
+  import type { UserInfo, UserOrgs } from '$lib/interfaces';
   import { Link16, Location16, Mail16, Organization16, People16 } from 'svelte-octicons';
 
   export let userInfo: UserInfo;

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { UserInfo, UserOrgs } from '../../interfaces';
+  import type { UserInfo, UserOrgs } from '../../../interfaces';
   import { Link16, Location16, Mail16, Organization16, People16 } from 'svelte-octicons';
 
   export let userInfo: UserInfo;

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.spec.ts
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.spec.ts
@@ -1,0 +1,10 @@
+import { beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ProfileNavSection from './ProfileNavSection.svelte';
+
+describe('ProfileNavSection', () => {
+  beforeEach(() => {
+    render(ProfileNavSection, {
+    });
+  });
+});

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
@@ -1,16 +1,17 @@
-<nav>
-    <ul>
-      <li class="active-tab">
-        <a href="/">
-          <!-- <span class="icon" appOcticon="repo" size="24"></span> -->
-          <span>Repositories</span>
-        </a>
-      </li>
-    </ul>
-</nav>
+<script lang="ts">
+  import { Repo24 } from 'svelte-octicons';
+</script>
+
+<ul>
+  <li class="active-tab">
+    <a href="/">
+      <Repo24 class="icon"/>
+      <span>Repositories</span>
+    </a>
+  </li>
+</ul>
 
 <style lang="scss">
-nav {
   ul {
     list-style: none;
     padding: 0;
@@ -56,5 +57,4 @@ nav {
     display: inline-block;
     margin-right: 4px;
   }
-}
 </style>

--- a/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
@@ -1,0 +1,60 @@
+<nav>
+    <ul>
+      <li class="active-tab">
+        <a href="/">
+          <!-- <span class="icon" appOcticon="repo" size="24"></span> -->
+          <span>Repositories</span>
+        </a>
+      </li>
+    </ul>
+</nav>
+
+<style lang="scss">
+nav {
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    a {
+      display: inline-block;
+      text-decoration: none;
+      line-height: 24px;
+      padding: 16px;
+      color: rgb(75, 85, 99);
+    }
+
+    span {
+      vertical-align: middle;
+    }
+
+    li {
+      display: inline-block;
+    }
+
+    .active-tab {
+      border-bottom: 2px solid;
+      border-color: rgba(245, 158, 11, 1);
+
+      span {
+        font-weight: 600;
+        color: black;
+
+        &.icon {
+          color: rgb(75, 85, 99);
+        }
+      }
+
+      &:hover,
+      &:focus {
+        border-color: rgb(209, 213, 219);
+      }
+    }
+  }
+
+  .icon {
+    display: inline-block;
+    margin-right: 4px;
+  }
+}
+</style>

--- a/svelte-kit-scss/src/lib/components/RepoControls/RepoControls.svelte
+++ b/svelte-kit-scss/src/lib/components/RepoControls/RepoControls.svelte
@@ -1,0 +1,1 @@
+<p>Repo Controls will go here</p>

--- a/svelte-kit-scss/src/lib/components/RepoList/RepoList.svelte
+++ b/svelte-kit-scss/src/lib/components/RepoList/RepoList.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { UserReposState } from '$lib/interfaces';
+  import RepositoryCard from '../RepositoryCard/RepositoryCard.svelte';
+
+  export let repos: UserReposState[];
+</script>
+
+<ul>
+  {#if Array.isArray(repos)}
+    {#each repos as repo}
+      <li>
+        <RepositoryCard {repo} />
+      </li>
+    {/each}
+  {/if}
+</ul>
+
+<style lang="scss">
+  ul {
+    list-style: none;
+
+    li {
+      padding: 32px 0;
+      border-bottom: 1px solid #e5e7eb;
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.svelte
+++ b/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.svelte
@@ -5,7 +5,8 @@
   import { LANGUAGE_COLORS } from '$lib/constants/language-colors';
 
   export let repo: UserReposState;
-  export let username: string;
+
+  const href = repo ? `/${repo.owner.login}/${repo.name}` : '#';
 
   function visibility(): string {
     if (repo) {
@@ -21,7 +22,7 @@
 </script>
 
 <h3 class="name-container" data-testid="repo-card">
-  <a class="name" href="/{username}/{repo.name}">{repo.name}</a>
+  <a class="name" {href}>{repo.name}</a>
   <span class="visibility">{visibility()}</span>
 </h3>
 {#if repo.description}

--- a/svelte-kit-scss/src/lib/components/TopRepositories/TopRepositories.svelte
+++ b/svelte-kit-scss/src/lib/components/TopRepositories/TopRepositories.svelte
@@ -3,7 +3,7 @@
   import RepositoryCard from '$lib/components/RepositoryCard/RepositoryCard.svelte';
 
   export let repos: UserReposState[];
-  export let username: string;
+  export let username: string | undefined;
 </script>
 
 <div class="top-repositories-container" data-testid="top-repos">
@@ -11,7 +11,7 @@
   <div class="repo-container">
     {#each repos as repo, i}
       <div class="repo-section">
-        <RepositoryCard {repo} {username} />
+        <RepositoryCard {repo} />
       </div>
       {#if i === repos.length - 1}
         <div class="view-all-link">

--- a/svelte-kit-scss/src/lib/helpers/index.ts
+++ b/svelte-kit-scss/src/lib/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './repositories';
 export * from './relativeTimeFmt';
 export * from './gists';
+export * from './user';

--- a/svelte-kit-scss/src/lib/helpers/user.ts
+++ b/svelte-kit-scss/src/lib/helpers/user.ts
@@ -1,4 +1,11 @@
-import type { UserApiResponse, UserInfo, UserOrgsApiResponse, UserOrgs } from '../interfaces';
+import type {
+  UserApiResponse,
+  UserInfo,
+  UserOrgsApiResponse,
+  UserOrgs,
+  UserReposState,
+  UserReposApiResponse,
+} from '../interfaces';
 
 export const mapUserInfoResponseToUserInfo = (user?: UserApiResponse): UserInfo | undefined => {
   return user
@@ -20,9 +27,41 @@ export const mapUserInfoResponseToUserInfo = (user?: UserApiResponse): UserInfo 
 };
 
 export const mapUserOrgsApiResponseToUserOrgs = (userOrgs: UserOrgsApiResponse): UserOrgs[] => {
-  return userOrgs.map((org) => ({
-    id: org.id,
-    login: org.login,
-    avatar_url: org.avatar_url,
-  }));
+  return Array.isArray(userOrgs)
+    ? userOrgs.map((org) => ({
+        id: org.id,
+        login: org.login,
+        avatar_url: org.avatar_url,
+      }))
+    : [];
+};
+
+export const mapUserReposApiResponseToUserReposStates = (
+  userRepos: UserReposApiResponse
+): UserReposState[] => {
+  return Array.isArray(userRepos)
+    ? userRepos.map((repo) => ({
+        name: repo.name,
+        description: repo.description,
+        language: repo.language,
+        stargazers_count: repo.stargazers_count,
+        forks_count: repo.forks_count,
+        private: repo.private,
+        updated_at: repo.updated_at,
+        fork: repo.fork,
+        archived: repo.archived,
+        license: repo.license
+          ? {
+              key: repo.license.key,
+              name: repo.license.name,
+              spdx_id: repo.license.spdx_id,
+              url: repo.license.url,
+              node_id: repo.license.node_id,
+            }
+          : null,
+        owner: {
+          login: repo.owner.login,
+        },
+      }))
+    : [];
 };

--- a/svelte-kit-scss/src/routes/(authenticated)/(home)/+page.server.ts
+++ b/svelte-kit-scss/src/routes/(authenticated)/(home)/+page.server.ts
@@ -26,6 +26,7 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
     return {
       topRepos: mapUserReposToTopRepos(repos),
       gists: mapGistsToHomeGists(gists),
+      username: userInfo?.username,
     };
   } catch (err) {
     // TODO: investigate better ways to handle and prompt users on errors

--- a/svelte-kit-scss/src/routes/(authenticated)/(home)/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/(home)/+page.svelte
@@ -9,10 +9,12 @@
 <div class="container">
   <div class="page-container">
     <aside>
-      <Gists gists={data.gists} />
+      {#if data?.gists}
+        <Gists gists={data.gists} />
+      {/if}
     </aside>
     {#if data?.topRepos}
-      <TopRepositories repos={data.topRepos} username="thisdot" />
+      <TopRepositories repos={data.topRepos} username={data?.username} />
     {/if}
   </div>
 </div>

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.server.ts
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.server.ts
@@ -1,20 +1,25 @@
 import type { PageServerLoad } from './$types';
-import type { UserApiResponse, UserOrgsApiResponse } from '$lib/interfaces';
-import { mapUserInfoResponseToUserInfo, mapUserOrgsApiResponseToUserOrgs } from '$lib/helpers/user';
+import type { UserApiResponse, UserOrgsApiResponse, UserReposApiResponse } from '$lib/interfaces';
+import {
+  mapUserInfoResponseToUserInfo,
+  mapUserOrgsApiResponseToUserOrgs,
+  mapUserReposApiResponseToUserReposStates,
+} from '$lib/helpers/user';
 import { ENV } from '$lib/constants/env';
 
 export const load: PageServerLoad = async ({ fetch, params }) => {
   const fetchUserInfoUrl = new URL(`/users/${params.username}`, ENV.GITHUB_URL);
-  const [userInfo, userOrgs] = await Promise.all([
-    fetch(fetchUserInfoUrl.toString()).then(
-      (response) => response.json() as Promise<UserApiResponse>
-    ),
-    fetch(`https://api.github.com/user/orgs`).then(
-      (response) => response.json() as Promise<UserOrgsApiResponse>
-    ),
+  const fetchUserOrgsUrl = new URL(`/users/${params.username}`, ENV.GITHUB_URL);
+  const fetchReposUrl = new URL(`/users/${params.username}/repos`, ENV.GITHUB_URL);
+
+  const [userInfo, userOrgs, userRepos] = await Promise.all([
+    fetch(fetchUserInfoUrl).then((response) => response.json() as Promise<UserApiResponse>),
+    fetch(fetchUserOrgsUrl).then((response) => response.json() as Promise<UserOrgsApiResponse>),
+    fetch(fetchReposUrl).then((response) => response.json() as Promise<UserReposApiResponse>),
   ]);
   return {
     userInfo: mapUserInfoResponseToUserInfo(userInfo),
     userOrgs: mapUserOrgsApiResponseToUserOrgs(userOrgs),
+    userRepos: mapUserReposApiResponseToUserReposStates(userRepos),
   };
 };

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.server.ts
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.server.ts
@@ -4,7 +4,7 @@ import {
   mapUserInfoResponseToUserInfo,
   mapUserOrgsApiResponseToUserOrgs,
   mapUserReposApiResponseToUserReposStates,
-} from '$lib/helpers/user';
+} from '$lib/helpers';
 import { ENV } from '$lib/constants/env';
 
 export const load: PageServerLoad = async ({ fetch, params }) => {
@@ -17,6 +17,7 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
     fetch(fetchUserOrgsUrl).then((response) => response.json() as Promise<UserOrgsApiResponse>),
     fetch(fetchReposUrl).then((response) => response.json() as Promise<UserReposApiResponse>),
   ]);
+
   return {
     userInfo: mapUserInfoResponseToUserInfo(userInfo),
     userOrgs: mapUserOrgsApiResponseToUserOrgs(userOrgs),

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -5,6 +5,8 @@
   import type { UserReposState } from '$lib/interfaces';
 
   export let data: PageServerData;
+  const { userInfo, userOrgs } = data;
+  const { type } = userInfo;
 </script>
 
 <div class="grid grid-cols-12 profile-body container">
@@ -19,7 +21,18 @@
       <RepoList repos={data?.userRepos} />
     {/if}
   </div>
-</div>
+
+  <div class="grid grid-cols-12 profile-body container">
+    
+    {#if type == ProfileType.User}
+      <div class="subpage col-span-3">
+        <ProfileAboutSection userInfo={userInfo} userOrgs={userOrgs} />
+      </div>
+    {/if}
+    <!-- <app-repo-controls class="col-span-9"></app-repo-controls> -->
+    <!-- <app-repo-list class="col-span-9" [repos]="repos$ | async"></app-repo-list> -->
+  </div>
+</main>
 
 <style lang="scss">
   .profile-body {

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
   import type { PageServerData } from './$types';
   import ProfileAboutSection from '$lib/components/ProfileAboutSection/ProfileAboutSection.svelte';
+  import RepoList from '$lib/components/RepoList/RepoList.svelte';
+  import type { UserReposState } from '$lib/interfaces';
 
   export let data: PageServerData;
 </script>
 
 <div class="grid grid-cols-12 profile-body container">
   <div class="subpage col-span-3">
-    <ProfileAboutSection userInfo={data.userInfo} userOrgs={data.userOrgs} />
+    {#if data?.userInfo}
+      <ProfileAboutSection userInfo={data.userInfo} userOrgs={data.userOrgs} />
+    {/if}
+  </div>
+  <div class="col-span-9">
+    {#if data?.userRepos}
+      <RepoList repos={data?.userRepos} />
+    {/if}
   </div>
 </div>
 

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -4,9 +4,10 @@
   import ProfileAboutSection from '$lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte';
   import ProfileNavSection from '$lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte';
   import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
+  import RepoList from '../../../lib/components/RepoList/RepoList.svelte';
 
   export let data: PageServerData;
-  const { userInfo, userOrgs } = data;
+  const { userInfo, userOrgs, userRepos, username } = data;
   const isOrg = userInfo?.type == ProfileType.Organization;
 </script>
 
@@ -30,13 +31,17 @@
   <div class="grid grid-cols-12 profile-body container">
     {#if isOrg}
       <!-- TODO controls -->
-      <!-- TODO repo list -->
+      <div class="col-span-12">
+        <RepoList repos={userRepos} {username} />
+      </div>
     {:else}
       <div class="subpage col-span-3">
         <ProfileAboutSection userInfo={userInfo} userOrgs={userOrgs} />
       </div>
       <!-- TODO controls -->
-      <!-- TODO repo list -->
+      <div class="col-span-9">
+        <RepoList repos={userRepos} {username} />
+      </div>
     {/if}
   </div>
 </div>

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -7,22 +7,22 @@
 
   export let data: PageServerData;
   const { userInfo, userOrgs } = data;
-  const isOrg = userInfo.type == ProfileType.Organization;
+  const isOrg = userInfo?.type == ProfileType.Organization;
 </script>
 
 <div class="profile-container">
   <div class="profile-header">
     <div class="grid grid-cols-12 container">
       {#if isOrg}
-          <OrgInfo class="col-span-12"></OrgInfo>
-          <nav class="col-span-12">
-            <ProfileNavSection ></ProfileNavSection>
-          </nav>
+        <OrgInfo />
+        <nav class="col-span-12">
+          <ProfileNavSection />
+        </nav>
       {:else}
-          <div class="col-span-3"></div>
-          <nav class="col-span-9">
-            <ProfileNavSection ></ProfileNavSection>
-          </nav>
+        <div class="col-span-3"></div>
+        <nav class="col-span-9">
+          <ProfileNavSection />
+        </nav>
       {/if}
     </div>
   </div>

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -5,6 +5,7 @@
   import ProfileNavSection from '$lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte';
   import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
   import RepoList from '../../../lib/components/RepoList/RepoList.svelte';
+  import RepoControls from '../../../lib/components/RepoControls/RepoControls.svelte';
 
   export let data: PageServerData;
   const { userInfo, userOrgs, userRepos, username } = data;
@@ -30,16 +31,16 @@
   
   <div class="grid grid-cols-12 profile-body container">
     {#if isOrg}
-      <!-- TODO controls -->
       <div class="col-span-12">
+        <RepoControls />
         <RepoList repos={userRepos} {username} />
       </div>
     {:else}
       <div class="subpage col-span-3">
         <ProfileAboutSection userInfo={userInfo} userOrgs={userOrgs} />
       </div>
-      <!-- TODO controls -->
       <div class="col-span-9">
+        <RepoControls />
         <RepoList repos={userRepos} {username} />
       </div>
     {/if}

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -1,45 +1,67 @@
 <script lang="ts">
   import type { PageServerData } from './$types';
-  import ProfileAboutSection from '$lib/components/ProfileAboutSection/ProfileAboutSection.svelte';
-  import RepoList from '$lib/components/RepoList/RepoList.svelte';
-  import type { UserReposState } from '$lib/interfaces';
+  import { ProfileType } from '$lib/interfaces';
+  import ProfileAboutSection from '$lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte';
+  import ProfileNavSection from '$lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte';
+  import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
 
   export let data: PageServerData;
   const { userInfo, userOrgs } = data;
-  const { type } = userInfo;
+  const isOrg = userInfo.type == ProfileType.Organization;
 </script>
 
-<div class="grid grid-cols-12 profile-body container">
-  Hello
-  <div class="subpage col-span-3">
-    {#if data?.userInfo}
-      <ProfileAboutSection userInfo={data.userInfo} userOrgs={data.userOrgs} />
-    {/if}
+<div class="profile-container">
+  <div class="profile-header">
+    <div class="grid grid-cols-12 container">
+      {#if isOrg}
+          <OrgInfo class="col-span-12"></OrgInfo>
+          <nav class="col-span-12">
+            <ProfileNavSection ></ProfileNavSection>
+          </nav>
+      {:else}
+          <div class="col-span-3"></div>
+          <nav class="col-span-9">
+            <ProfileNavSection ></ProfileNavSection>
+          </nav>
+      {/if}
+    </div>
   </div>
-  <div class="col-span-9">
-    {#if data?.userRepos}
-      <RepoList repos={data?.userRepos} />
-    {/if}
-  </div>
-
+  
   <div class="grid grid-cols-12 profile-body container">
-    
-    {#if type == ProfileType.User}
+    {#if isOrg}
+      <!-- TODO controls -->
+      <!-- TODO repo list -->
+    {:else}
       <div class="subpage col-span-3">
         <ProfileAboutSection userInfo={userInfo} userOrgs={userOrgs} />
       </div>
+      <!-- TODO controls -->
+      <!-- TODO repo list -->
     {/if}
-    <!-- <app-repo-controls class="col-span-9"></app-repo-controls> -->
-    <!-- <app-repo-list class="col-span-9" [repos]="repos$ | async"></app-repo-list> -->
   </div>
-</main>
+</div>
 
 <style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+  .profile-container {
+    padding-top: 2rem;
+  }
+  .profile-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background-color: white;
+    border-bottom: 1px solid rgb(229, 231, 235, 1);
+  }
   .profile-body {
     grid-template-rows: max-content 1fr;
 
     .subpage {
       grid-row: 1 / 3;
     }
+  }
+  
+  .container {
+    max-width: variables.$xl;
   }
 </style>

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -8,6 +8,7 @@
 </script>
 
 <div class="grid grid-cols-12 profile-body container">
+  Hello
   <div class="subpage col-span-3">
     {#if data?.userInfo}
       <ProfileAboutSection userInfo={data.userInfo} userOrgs={data.userOrgs} />


### PR DESCRIPTION
Resolves: #678

User Profile result:
![image](https://user-images.githubusercontent.com/15368874/199257347-db104c94-9426-4bf1-9028-60d0a232e2f5.png)

Org Profile result:
![image](https://user-images.githubusercontent.com/15368874/199257581-a060c8c2-3e09-4d0c-85ec-ce1e84b83da6.png)


# Create profile page layout

## Background

As a user, I can navigate to my profile page and see my profile information, as well as a list of all my repositories. I can also see options to search my repositories, sort them, and filter them. (Functionality does not need to work yet for these options, they just need to be visible.)

## Acceptance

- [x] 2 column layout
- [x] sub-header spanning both columns, showing book icon and repositories title - should be sticky on scroll
- [x] Left side
    - [x] user profile card
- [x] Right side - 
    - [x] search / filter / sort component
    - [x] card for all user repositories

## Notes

