### PR TITLE
[qwik-pod]:c Implement type filter functionality

### DIFF
--- a/qwik-graphql-tailwind/src/components/filter-dropdown/filter-dropdown.tsx
+++ b/qwik-graphql-tailwind/src/components/filter-dropdown/filter-dropdown.tsx
@@ -1,4 +1,4 @@
-import { $, component$, useSignal, useStore } from '@builder.io/qwik';
+import { $, component$, Slot, useSignal, useStore } from '@builder.io/qwik';
 import { CheckIcon, ChevronDownIcon, XmarkIcon } from '../icons';
 import * as styles from './filter-dropdown.classNames';
 import cn from 'classnames';
@@ -13,7 +13,7 @@ export interface FilterDropdownProps {
   name: string;
   description?: string;
   current: number | string | null;
-  items: Option[];
+  items?: Option[];
   buttonClassName?: string;
 }
 
@@ -57,18 +57,20 @@ export const FilterDropdown = component$(
               {description && (
                 <div className={styles.menuHeader}>
                   <div className={styles.description}>{description}</div>
-                  <button type="button">
+                  <button onClick$={close$} type="button">
                     <XmarkIcon className={styles.closeButtonIcon} aria-hidden="true" />
                   </button>
                 </div>
               )}
-              {items.map(({ label, value }) => (
-                <div>
-                  <button type="button" name={name} className={styles.itemButton}>
-                    {value === current && <CheckIcon className={styles.itemActiveIcon} />} {label}
-                  </button>
-                </div>
-              ))}
+              {items &&
+                items.map(({ label, value }) => (
+                  <div>
+                    <button onClick$={() => null} type="button" name={name} className={styles.itemButton}>
+                      {value === current && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                    </button>
+                  </div>
+                ))}
+              <Slot />
             </div>
           </nav>
         </div>

--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.classNames.ts
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.classNames.ts
@@ -7,3 +7,6 @@ export const clearBtnIconContainer =
   'p-0.5 rounded bg-gray-500 inline-flex items-center justify-center mr-2 group-hover:bg-blue-500';
 export const clearBtnIcon = 'w-3.5 h-3.5 text-white';
 export const clearBtnText = 'text-sm text-gray-500 group-hover:text-blue-500';
+export const itemButton =
+  'relative w-full text-left text-xs py-2 px-10 border-t border-gray-300 hover:bg-gray-100 capitalize';
+export const itemActiveIcon = 'inline w-4 h-4 absolute left-4';

--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
@@ -1,10 +1,11 @@
-import { $, component$ } from '@builder.io/qwik';
+import { $, component$, useClientEffect$, useContext } from '@builder.io/qwik';
 import * as styles from './repo-filters.classNames';
 import cn from 'classnames';
 import { LanguageFilter, TypeFilter, RepositoryOrderField } from './types';
 import { FilterDropdown } from '../filter-dropdown/filter-dropdown';
-import { XmarkIcon } from '../icons';
+import { XmarkIcon, CheckIcon } from '../icons';
 import { SearchInput } from '../search-input/search-input';
+import filterStore from '~/context/repo-filter';
 
 export type RepoFiltersProps = {
   languages: LanguageFilter[];
@@ -17,11 +18,28 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
     console.log('reset filters');
   });
 
+  const state = useContext(filterStore);
+
   // TODO: logic for this
   const isFiltersActive = false;
   const isQueryActive = false;
   const isTypeActive = false;
   const isLanguageActive = false;
+
+  const filteOptions = [
+    {
+      label: 'All',
+      value: TypeFilter.ALL,
+    },
+    {
+      label: 'Forks',
+      value: TypeFilter.FORKS,
+    },
+    {
+      label: 'Archived',
+      value: TypeFilter.ARCHIVED,
+    },
+  ];
 
   return (
     <>
@@ -31,25 +49,20 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
         </div>
         <div className={styles.filters}>
           <div>
-            <FilterDropdown
-              name="Type"
-              description="Select type"
-              current=""
-              items={[
-                {
-                  label: 'All',
-                  value: TypeFilter.ALL,
-                },
-                {
-                  label: 'Forks',
-                  value: TypeFilter.FORKS,
-                },
-                {
-                  label: 'Archived',
-                  value: TypeFilter.ARCHIVED,
-                },
-              ]}
-            />
+            <FilterDropdown name="Type" description="Select type" current="">
+              {filteOptions.map(({ label, value }) => (
+                <div>
+                  <button
+                    onClick$={() => (state.filterType = value)}
+                    type="button"
+                    name={'Type'}
+                    className={styles.itemButton}
+                  >
+                    {value === state.filterType && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                  </button>
+                </div>
+              ))}
+            </FilterDropdown>
           </div>
           <div>
             <FilterDropdown name="Language" description="Select language" current="" items={languages} />

--- a/qwik-graphql-tailwind/src/components/user-dropdown/user-dropdown.tsx
+++ b/qwik-graphql-tailwind/src/components/user-dropdown/user-dropdown.tsx
@@ -52,7 +52,7 @@ export const UserDropdown = component$(({ image, username }: UserDropdownProps) 
           <ul className="py-1">
             {username && (
               <li data-menu-item>
-                <Link href={`/${username}`} className={styles.menuBtn}>
+                <Link preventdefault:click={false} href={`/${username}`} className={styles.menuBtn}>
                   Profile
                 </Link>
               </li>

--- a/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
+++ b/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
@@ -1,3 +1,4 @@
+import { TypeFilter } from '../repo-filters/types';
 import { UserRepo } from './types';
 
 // Function to filter repos by search
@@ -12,4 +13,19 @@ export const repoDataFilteredBySearch = (search: string, repos: UserRepo[]): Use
 
     return [...acc, repo];
   }, []);
+};
+
+export const repoDataFilteredByType = (filterType: string, repos: UserRepo[]): UserRepo[] => {
+  let response = repos.slice();
+  if (filterType === TypeFilter.FORKS) {
+    console.log('====================================');
+    console.log(response, TypeFilter.FORKS);
+    console.log('====================================');
+    response = repos.filter((repo) => repo.isFork);
+  } else if (filterType === TypeFilter.ARCHIVED) {
+    response = repos.filter((repo) => repo.isArchived);
+  } else if (filterType === TypeFilter.ALL) {
+    response = repos;
+  }
+  return response;
 };

--- a/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
+++ b/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
@@ -18,9 +18,6 @@ export const repoDataFilteredBySearch = (search: string, repos: UserRepo[]): Use
 export const repoDataFilteredByType = (filterType: string, repos: UserRepo[]): UserRepo[] => {
   let response = repos.slice();
   if (filterType === TypeFilter.FORKS) {
-    console.log('====================================');
-    console.log(response, TypeFilter.FORKS);
-    console.log('====================================');
     response = repos.filter((repo) => repo.isFork);
   } else if (filterType === TypeFilter.ARCHIVED) {
     response = repos.filter((repo) => repo.isArchived);

--- a/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
+++ b/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
@@ -9,12 +9,14 @@ import { Pagination } from '../pagination/pagination';
 import { RepoFilters } from '../repo-filters/repo-filters';
 import { getLanguages } from './getLanguages';
 import filterStore from '~/context/repo-filter';
-import { repoDataFilteredBySearch } from './filter-sort-functions';
+import { repoDataFilteredBySearch, repoDataFilteredByType } from './filter-sort-functions';
 
 export const UserRepos = component$(({ repos, owner }: UserReposProps) => {
   const languages = getLanguages(repos.nodes);
 
   const searchValue = useContext(filterStore);
+
+  const filterByType = repoDataFilteredByType(searchValue.filterType, repos.nodes);
 
   const filteredAndSortedRepos = ((): UserRepo[] => {
     const searchResponse = repoDataFilteredBySearch(searchValue?.search || '', repos.nodes);
@@ -24,7 +26,7 @@ export const UserRepos = component$(({ repos, owner }: UserReposProps) => {
   return (
     <>
       <RepoFilters languages={languages} resultCount={repos.nodes.length} />
-      {filteredAndSortedRepos.map(
+      {filterByType.map(
         ({ id, name, description, stargazerCount, forkCount, primaryLanguage, updatedAt, isPrivate }) => (
           <div key={id} className={styles.container}>
             <div className={styles.content}>

--- a/qwik-graphql-tailwind/src/context/repo-filter.ts
+++ b/qwik-graphql-tailwind/src/context/repo-filter.ts
@@ -2,7 +2,7 @@ import { createContext } from '@builder.io/qwik';
 export interface FilterStoreProps {
   search: string;
   language: string;
-  sortType: string;
+  filterType: string;
   order: string;
 }
 const filterStore = createContext<FilterStoreProps>('filter-context');

--- a/qwik-graphql-tailwind/src/routes/[user]/index.tsx
+++ b/qwik-graphql-tailwind/src/routes/[user]/index.tsx
@@ -9,6 +9,7 @@ import { UserProfileCard } from '../../components/user-profile-card/user-profile
 import ProfileNav from '../../components/profile-nav/profile-nav';
 import { UserRepos } from '../../components/user-repos/user-repos';
 import filterStore, { FilterStoreProps } from '~/context/repo-filter';
+import { TypeFilter } from '~/components/repo-filters/types';
 
 interface UserStore {
   user: User | null;
@@ -29,7 +30,7 @@ export default component$(() => {
   const filterState = useStore<FilterStoreProps>({
     search: '',
     language: '',
-    sortType: '',
+    filterType: TypeFilter.ALL,
     order: '',
   });
 


### PR DESCRIPTION
# Implement type filter functionality

## Background

In another ticket, a component was created with the type dropdown button. The purpose of this ticket is to add the functionality and populate the fields for that button. The options that should be available to the user are listed below - when a user selects an option, the repository list on the page should be filtered to only include ones that match the user’s selection.

## Acceptance

- [x] when an option is selected, will filter the current results based on the selected option
- [x] Type dropdown options: all (default), forks, archived
- [x] only one selection allowed, noted with a check mark icon

## Notes

![Screenshot 2022-11-02 at 15 39 27](https://user-images.githubusercontent.com/28502531/199520595-b212783a-04e5-45f2-babd-76dce5f30aa1.jpg)
![Screenshot 2022-11-02 at 15 39 38](https://user-images.githubusercontent.com/28502531/199520616-58b8d585-cb85-40f7-bd6e-4b8876e872f8.jpg)
