### PR TITLE
[sveltekit-pod] 25 Create single repo view sub header

### DIFF
--- a/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
+++ b/svelte-kit-scss/src/lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte
@@ -5,7 +5,9 @@
 <ul>
   <li class="active-tab">
     <a href="/">
-      <Repo24 class="icon" />
+      <span class="icon">
+        <Repo24 />
+      </span>
       <span>Repositories</span>
     </a>
   </li>

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeader.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeader.svelte
@@ -5,15 +5,16 @@
   import RepoNavigation from './RepoNavigation/RepoNavigation.svelte';
 
   export let repo: RepoState;
+  const { watchCount, starCount, forkCount, issueCount, prCount } = repo;
 </script>
 
 <div class="wrapper">
   {#if repo}
     <div class="top">
-      <RepoHeading />
-      <RepoInfo />
+      <RepoHeading {repo} />
+      <RepoInfo {watchCount} {starCount} {forkCount} />
     </div>
-    <RepoNavigation />
+    <RepoNavigation {repo} {issueCount} {prCount} />
   {/if}
 </div>
 

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
@@ -9,6 +9,10 @@
     return `/${repo?.ownerName}`;
   };
 
+  const repoPath = () => {
+    return `/${repo?.ownerName}/${repo?.repoName}`;
+  };
+
   const visibility = () => {
     return repo?.visibility || '';
   };
@@ -19,7 +23,7 @@
   <div class="heading__breadcrumb">
     <a href={ownerPath()}>{repo?.ownerName}</a>
     <span>/</span>
-    <a href="./" class="bold">{repo?.repoName}</a>
+    <a href={repoPath()} class="bold">{repo?.repoName}</a>
   </div>
   {#if repo?.visibility}
     <div class="heading__privacy">

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
@@ -5,29 +5,25 @@
 
   export let repo: RepoState;
 
-  const ownerPath = () => {
-    return `/${repo?.ownerName}`;
-  };
+  const ownerPath = `/${repo?.ownerName}`;
 
-  const repoPath = () => {
-    return `/${repo?.ownerName}/${repo?.repoName}`;
-  };
+  const repoPath = `/${repo?.ownerName}/${repo?.repoName}`;
 
-  const visibility = () => {
-    return repo?.visibility || '';
-  };
+  const visibility = repo?.visibility || '';
 </script>
 
 <div class="heading">
-  <Repo24 class="icon" />
+  <span class="icon">
+    <Repo24 />
+  </span>
   <div class="heading__breadcrumb">
-    <a href={ownerPath()}>{repo?.ownerName}</a>
+    <a href={ownerPath}>{repo?.ownerName}</a>
     <span>/</span>
-    <a href={repoPath()} class="bold">{repo?.repoName}</a>
+    <a href={repoPath} class="bold">{repo?.repoName}</a>
   </div>
   {#if repo?.visibility}
     <div class="heading__privacy">
-      <span>{titleCase(visibility())}</span>
+      <span>{titleCase(visibility)}</span>
     </div>
   {/if}
 </div>

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoHeading/RepoHeading.svelte
@@ -1,1 +1,67 @@
-<p>Repo Heading</p>
+<script lang="ts">
+  import type { RepoState } from '$lib/interfaces';
+  import { titleCase } from '$lib/helpers/formatting';
+  import { Repo24 } from 'svelte-octicons';
+
+  export let repo: RepoState;
+
+  const ownerPath = () => {
+    return `/${repo?.ownerName}`;
+  };
+
+  const visibility = () => {
+    return repo?.visibility || '';
+  };
+</script>
+
+<div class="heading">
+  <Repo24 class="icon" />
+  <div class="heading__breadcrumb">
+    <a href={ownerPath()}>{repo?.ownerName}</a>
+    <span>/</span>
+    <a href="./" class="bold">{repo?.repoName}</a>
+  </div>
+  {#if repo?.visibility}
+    <div class="heading__privacy">
+      <span>{titleCase(visibility())}</span>
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+
+  .heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &__breadcrumb {
+      margin-bottom: 0.25rem;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+
+      a {
+        font-size: 1.475rem;
+        color: variables.$blue600;
+        text-decoration: none;
+      }
+
+      span {
+        color: variables.$gray600;
+        font-size: 1.475rem;
+      }
+    }
+
+    &__privacy {
+      border-radius: 1rem;
+      color: variables.$gray600;
+      line-height: 1rem;
+      font-weight: 500;
+      border: 1px solid variables.$gray300;
+      padding: 0.2rem 0.7rem;
+      font-size: 0.875rem;
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoInfo/RepoInfo.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoInfo/RepoInfo.svelte
@@ -1,1 +1,66 @@
-<p>Repo Info</p>
+<script lang="ts">
+  import { Eye16, RepoForked16, Star16 } from 'svelte-octicons';
+
+  export let watchCount = 0,
+    starCount = 0,
+    forkCount = 0;
+</script>
+
+<div class="info">
+  <div class="info__counter">
+    <div class="info__counter__icon">
+      <Eye16 class="icon" />
+      Watch
+    </div>
+    <div class="info__counter__count">
+      {watchCount}
+    </div>
+  </div>
+  <div class="info__counter">
+    <div class="info__counter__icon">
+      <Star16 class="icon" />
+      Star
+    </div>
+    <div class="info__counter__count">
+      {starCount}
+    </div>
+  </div>
+  <div class="info__counter">
+    <div class="info__counter__icon">
+      <RepoForked16 class="icon" />
+      Fork
+    </div>
+    <div class="info__counter__count">
+      {forkCount}
+    </div>
+  </div>
+</div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+
+  .info {
+    display: flex;
+    gap: 0.9rem;
+    &__counter {
+      display: flex;
+      border: 2px solid variables.$gray200;
+      border-radius: 0.5rem;
+      font-size: 0.9rem;
+      &__icon {
+        display: flex;
+        align-items: center;
+        line-height: 0.5rem;
+        padding: 0.125rem 0.9rem;
+        gap: 0.5rem;
+        border-right: 2px solid variables.$gray200;
+      }
+      &__count {
+        border-top-right-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
+        background-color: variables.$white;
+        padding: 0.125rem 0.9rem;
+      }
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoInfo/RepoInfo.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoInfo/RepoInfo.svelte
@@ -9,7 +9,9 @@
 <div class="info">
   <div class="info__counter">
     <div class="info__counter__icon">
-      <Eye16 class="icon" />
+      <span class="icon">
+        <Eye16 />
+      </span>
       Watch
     </div>
     <div class="info__counter__count">
@@ -18,7 +20,9 @@
   </div>
   <div class="info__counter">
     <div class="info__counter__icon">
-      <Star16 class="icon" />
+      <span class="icon">
+        <Star16 />
+      </span>
       Star
     </div>
     <div class="info__counter__count">
@@ -27,7 +31,9 @@
   </div>
   <div class="info__counter">
     <div class="info__counter__icon">
-      <RepoForked16 class="icon" />
+      <span class="icon">
+        <RepoForked16 />
+      </span>
       Fork
     </div>
     <div class="info__counter__count">

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -1,1 +1,143 @@
-<p>Repo Navigation</p>
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import type { RepoState } from '$lib/interfaces';
+  import { Code16, GitPullRequest16, IssueOpened16 } from 'svelte-octicons';
+  import { page } from '$app/stores';
+  let path: string;
+
+  function getPath(currentPath: string) {
+    path = currentPath;
+  }
+
+  $: getPath($page.url.pathname);
+
+  export let repo: RepoState,
+    issueCount = 0,
+    prCount = 0;
+
+  function openCode() {
+    openTabLink('');
+  }
+
+  function openIssues() {
+    openTabLink('issues');
+  }
+
+  function openPRs() {
+    openTabLink('pull-requests');
+  }
+
+  function openTabLink(link: string) {
+    goto(`/${repo?.ownerName}/${repo?.repoName}/${link}`);
+  }
+</script>
+
+<div class="container">
+  <nav class="nav" aria-label="Tabs">
+    <ul>
+      <li
+        on:click={openCode}
+        on:keypress={openCode}
+        class="tab tab--inactive"
+        class:tab--active={!path.includes('issues') && !path.includes('pull-requests')}
+      >
+        <Code16 class="icon" />
+        <span>Code</span>
+      </li>
+      <li
+        on:click={openIssues}
+        on:keypress={openIssues}
+        class="tab tab--inactive"
+        class:tab--active={path.includes('issues')}
+      >
+        <IssueOpened16 class="icon" />
+        <span>Issues</span>
+        <span class="count">
+          {issueCount}
+        </span>
+      </li>
+      <li
+        on:click={openPRs}
+        on:keypress={openPRs}
+        class="tab tab--inactive"
+        class:tab--active={path.includes('pull-requests')}
+      >
+        <GitPullRequest16 class="icon" />
+        <span>Pull Requests</span>
+        <span class="count">
+          {prCount}
+        </span>
+      </li>
+    </ul>
+  </nav>
+</div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+  .container {
+    max-width: 1536px;
+    margin: 0 auto 0 0;
+    nav {
+      margin-bottom: -1px;
+      display: flex;
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+
+        li {
+          cursor: pointer;
+          display: inline-flex;
+          align-items: center;
+          text-decoration: none;
+          font-size: 1rem;
+          padding: 16px;
+          color: variables.$gray600;
+          &.tab {
+            &--active {
+              border-bottom: 2px solid rgba(245, 158, 11, 1);
+
+              span {
+                font-weight: 600;
+                color: black;
+
+                &.icon {
+                  color: variables.$gray600;
+                }
+              }
+            }
+          }
+          &:hover {
+            border-bottom: 2px solid variables.$gray300;
+          }
+          .count {
+            display: inline-block;
+            text-align: center;
+            padding: 0.125rem 0.5rem;
+            margin-left: 0.5rem;
+            background-color: #e5e7eb;
+            color: #1f2937;
+            font-size: 0.875rem;
+            line-height: 1.125rem;
+            font-weight: 500;
+            border-radius: 0.875rem;
+          }
+        }
+
+        span {
+          line-height: 1.175rem;
+        }
+
+        li {
+          display: inline-block;
+          font-weight: 500;
+        }
+      }
+
+      .icon {
+        display: inline-block;
+        margin-right: 0.5rem;
+      }
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -84,7 +84,6 @@
     max-width: variables.$lg;
     margin: 0 auto 0 0;
     nav {
-      margin-bottom: -1px;
       display: flex;
       ul {
         list-style: none;
@@ -119,7 +118,7 @@
           .count {
             display: inline-block;
             text-align: center;
-            padding: 0.125rem 0.5rem;
+            padding: 0 0.5rem;
             margin-left: 0.5rem;
             background-color: #e5e7eb;
             color: #1f2937;

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -41,7 +41,9 @@
         class="tab tab--inactive"
         class:tab--active={!path.includes('issues') && !path.includes('pull-requests')}
       >
-        <Code16 class="icon" />
+        <div class="icon">
+          <Code16 />
+        </div>
         <span>Code</span>
       </li>
       <li
@@ -50,7 +52,9 @@
         class="tab tab--inactive"
         class:tab--active={path.includes('issues')}
       >
-        <IssueOpened16 class="icon" />
+        <div class="icon">
+          <IssueOpened16 />
+        </div>
         <span>Issues</span>
         <span class="count">
           {issueCount}
@@ -62,7 +66,9 @@
         class="tab tab--inactive"
         class:tab--active={path.includes('pull-requests')}
       >
-        <GitPullRequest16 class="icon" />
+        <div class="icon">
+          <GitPullRequest16 />
+        </div>
         <span>Pull Requests</span>
         <span class="count">
           {prCount}
@@ -100,10 +106,10 @@
               span {
                 font-weight: 600;
                 color: black;
+              }
 
-                &.icon {
-                  color: variables.$gray600;
-                }
+              .icon {
+                color: variables.$gray600;
               }
             }
           }
@@ -129,13 +135,12 @@
         }
 
         li {
-          display: inline-block;
           font-weight: 500;
         }
       }
 
       .icon {
-        display: inline-block;
+        display: inline-flex;
         margin-right: 0.5rem;
       }
     }

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -100,7 +100,7 @@
           color: variables.$gray600;
           &.tab {
             &--active {
-              border-bottom: 2px solid rgba(245, 158, 11, 1);
+              border-bottom: 2px solid #f59e0b;
 
               span {
                 font-weight: 600;

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -81,7 +81,7 @@
 <style lang="scss">
   @use 'src/lib/styles/variables.scss';
   .container {
-    max-width: 1536px;
+    max-width: variables.$lg;
     margin: 0 auto 0 0;
     nav {
       margin-bottom: -1px;

--- a/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
+++ b/svelte-kit-scss/src/lib/components/Repo/RepoHeader/RepoNavigation/RepoNavigation.svelte
@@ -41,9 +41,9 @@
         class="tab tab--inactive"
         class:tab--active={!path.includes('issues') && !path.includes('pull-requests')}
       >
-        <div class="icon">
+        <span class="icon">
           <Code16 />
-        </div>
+        </span>
         <span>Code</span>
       </li>
       <li
@@ -52,9 +52,9 @@
         class="tab tab--inactive"
         class:tab--active={path.includes('issues')}
       >
-        <div class="icon">
+        <span class="icon">
           <IssueOpened16 />
-        </div>
+        </span>
         <span>Issues</span>
         <span class="count">
           {issueCount}
@@ -66,9 +66,9 @@
         class="tab tab--inactive"
         class:tab--active={path.includes('pull-requests')}
       >
-        <div class="icon">
+        <span class="icon">
           <GitPullRequest16 />
-        </div>
+        </span>
         <span>Pull Requests</span>
         <span class="count">
           {prCount}

--- a/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.svelte
+++ b/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { UserReposState } from '../../interfaces';
-  import { relativeTimeFmt } from '../../helpers';
+  import type { UserReposState } from '$lib/interfaces';
+  import { relativeTimeFmt } from '$lib/helpers';
   import { Law16, Star16, RepoForked16 } from 'svelte-octicons';
   import { LANGUAGE_COLORS } from '$lib/constants/language-colors';
 

--- a/svelte-kit-scss/src/lib/helpers/formatting.ts
+++ b/svelte-kit-scss/src/lib/helpers/formatting.ts
@@ -38,3 +38,7 @@ export function relativeTimeFmt(dt: string): string {
   const count = Math.floor(secondsAgo / divisor);
   return `${count} ${unit}${count > 1 ? 's' : ''} ago`;
 }
+
+export function titleCase(str: string): string {
+  return str.toLowerCase().replace(/\b\w/g, (s) => s.toUpperCase());
+}

--- a/svelte-kit-scss/src/lib/helpers/index.ts
+++ b/svelte-kit-scss/src/lib/helpers/index.ts
@@ -1,5 +1,5 @@
 export * from './repositories';
-export * from './relativeTimeFmt';
 export * from './gists';
 export * from './user';
 export * from './repository';
+export * from './formatting';

--- a/svelte-kit-scss/src/lib/helpers/repository.ts
+++ b/svelte-kit-scss/src/lib/helpers/repository.ts
@@ -15,7 +15,7 @@ export const mapRepoResToRepoState = (data: RepoApiResponse): RepoState => {
     openPullRequests: null,
     closedPullRequests: null,
     activeBranch: data.default_branch,
-    ownerName: '',
+    ownerName: data.owner.login,
     prCount: 0,
     readme: '',
     tree: [],

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -4,8 +4,8 @@
   import ProfileAboutSection from '$lib/components/Profile/ProfileAboutSection/ProfileAboutSection.svelte';
   import ProfileNavSection from '$lib/components/Profile/ProfileNavSection/ProfileNavSection.svelte';
   import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
-  import RepoList from '../../../lib/components/RepoList/RepoList.svelte';
-  import RepoControls from '../../../lib/components/RepoControls/RepoControls.svelte';
+  import RepoList from '$lib/components/RepoList/RepoList.svelte';
+  import RepoControls from '$lib/components/RepoControls/RepoControls.svelte';
 
   export let data: PageServerData;
   const { userInfo, userOrgs, userRepos, username } = data;
@@ -33,7 +33,7 @@
     {#if isOrg}
       <div class="col-span-12">
         <RepoControls />
-        <RepoList repos={userRepos} {username} />
+        <RepoList repos={userRepos} />
       </div>
     {:else}
       <div class="subpage col-span-3">
@@ -41,7 +41,7 @@
       </div>
       <div class="col-span-9">
         <RepoControls />
-        <RepoList repos={userRepos} {username} />
+        <RepoList repos={userRepos} />
       </div>
     {/if}
   </div>

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -131,7 +131,7 @@
     top: 0;
     z-index: 5;
     background-color: white;
-    border-bottom: 1px solid rgb(229, 231, 235, 1);
+    border-bottom: 1px solid #fcba03;
   }
   .profile-body {
     grid-template-rows: max-content 1fr;

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -7,62 +7,62 @@
   import RepoControls from '$lib/components/shared/RepoControls/RepoControls.svelte';
   import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
   import type { RepoFiltersState } from '$lib/components/shared/RepoControls/repo-filters-state';
-  import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';  
-  export let data: PageServerData;
+  import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';
 
+  export let data: PageServerData;
 
   // sample:
   const handleFiltersChange = (event: CustomEvent<RepoFiltersState>): void => {
     console.log('[handleFiltersChange]', event.detail);
-  }
-  
+  };
+
   const typeFilters: FilterDropdownOption[] = [
     {
       label: 'All',
-      value: 'all'
+      value: 'all',
     },
     {
       label: 'Forked',
-      value: 'forked'
+      value: 'forked',
     },
     {
       label: 'Archived',
-      value: 'archived'
-    }
+      value: 'archived',
+    },
   ];
 
   const languageFilters: FilterDropdownOption[] = [
     {
       label: 'All',
-      value: 'all'
+      value: 'all',
     },
     {
       label: 'Vue',
-      value: 'vue'
+      value: 'vue',
     },
     {
       label: 'JavaScript',
-      value: 'js'
+      value: 'js',
     },
     {
       label: 'TypeScript',
-      value: 'ts'
-    }
+      value: 'ts',
+    },
   ];
 
   const sortFilters: FilterDropdownOption[] = [
     {
       label: 'Last Updated',
-      value: 'updated'
+      value: 'updated',
     },
     {
       label: 'Name',
-      value: 'name'
+      value: 'name',
     },
     {
       label: 'Stars',
-      value: 'stars'
-    }
+      value: 'stars',
+    },
   ];
 
   const reposCount = 7;
@@ -97,7 +97,8 @@
           {typeFilters}
           {languageFilters}
           {sortFilters}
-          on:filtersChange={handleFiltersChange}/>
+          on:filtersChange={handleFiltersChange}
+        />
         <RepoList repos={userRepos} />
       </div>
     {:else}
@@ -108,11 +109,13 @@
       </div>
       <div class="col-span-9">
         <RepoControls
-            {reposCount}
-            {typeFilters}
-            {languageFilters}
-            {sortFilters}
-            on:filtersChange={handleFiltersChange}/>
+          {reposCount}
+          {typeFilters}
+          {languageFilters}
+          {sortFilters}
+          on:filtersChange={handleFiltersChange}
+        />
+        <RepoList repos={userRepos} />
       </div>
     {/if}
   </div>


### PR DESCRIPTION
Resolves: #782

Result: 
https://www.loom.com/share/e32a1a87c1fb42dfb3cdda234c68be56

# Create single repo view sub header

> ## Background
> 
> As a user, I can view a page for an individual repository with details about that repository. I can see the about information, tabs for code / issues / pull requests, info about how many watchers / stars / forks the repo has, and view the root folder’s contents in a file tree. At the bottom of the page I can also view the contents of the main readme page.
> 
> ## Acceptance
> 
> - [x] book icon with user name / repo name and visibility tag (public / private)
> - [x] buttons with icon, name, and count for: (buttons do not need to be functional)
>     - [x] watch
>     - [x] star
>     - [x] fork
> - [x] section will have three tab headers for different views (do not need to build the views, just the tab headers)
>     - [x] code w/ < > icon
>     - [x] issues with info icon and count of open issues
>     - [x] pull requests with icon and count of open requests
> 
> ## Notes
