### PR TITLE
[sveltekit-pod] 26 Create single repo view about section

### DIFF
--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { Book16, Link16 } from 'svelte-octicons';
+  import { handleAnchorClick } from '$lib/helpers';
+
+  export let description: string;
+  export let website: string;
+  export let tags: string[];
+</script>
+
+<div class="container border-bottom-2">
+  <h2>About</h2>
+  <div class="description mt-1">
+    <span data-testid="repo file explorer description">
+      {description ?? 'No description, website, or topics provided.'}
+    </span>
+
+    {#if website}
+      <div class="linkContainer mt-1">
+        <span class="icon">
+          <Link16 />
+        </span>
+        <a href={website} class="link" target="_blank" rel="noreferrer">
+          {website}
+        </a>
+      </div>
+    {/if}
+
+    {#if tags}
+      <div class="mt-1">
+        {#each tags as tag}
+          <span class="tag">{tag}</span>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  <div class="mt-1">
+    <a class="readMeLink" href="#readme" on:click={handleAnchorClick}>
+      <span class="icon">
+        <Book16 />
+      </span>
+      Readme
+    </a>
+  </div>
+</div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+  a {
+    color: variables.$gray500;
+  }
+
+  a > span,
+  .link {
+    margin-right: 0.5rem;
+  }
+
+  .mt-1 {
+    margin-top: 1rem;
+  }
+
+  .tag {
+    padding: 0.25rem 0.5rem;
+    margin-right: 0.375rem;
+    background-color: variables.$blue100;
+    transition-property: background-color, border-color, color, fill, stroke;
+    color: variables.$blue600;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 500;
+    border-radius: 0.75rem;
+    cursor: pointer;
+
+    &:hover {
+      background-color: variables.$blue600;
+      color: variables.$white;
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte
@@ -76,4 +76,8 @@
       color: variables.$white;
     }
   }
+  .border-bottom-2 {
+    border-bottom: 2px solid rgba(209, 213, 219, 1);
+    padding-bottom: 2rem;
+  }
 </style>

--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerContainer/FileExplorerContainer.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerContainer/FileExplorerContainer.svelte
@@ -1,0 +1,7 @@
+<p>File Explorer Container</p>
+
+<style lang="scss">
+  p {
+    height: 100vh;
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerNav/FileExplorerNav.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerNav/FileExplorerNav.svelte
@@ -1,0 +1,1 @@
+<p>File Explorer Nav</p>

--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
@@ -1,0 +1,3 @@
+<div id="readme">
+  <p>File Exploerer Readme</p>
+</div>

--- a/svelte-kit-scss/src/lib/helpers/handleAnchorClick.ts
+++ b/svelte-kit-scss/src/lib/helpers/handleAnchorClick.ts
@@ -1,0 +1,10 @@
+export function handleAnchorClick(event: Event) {
+  event.preventDefault();
+  const link = event.currentTarget;
+  const anchorId = new URL(link.href).hash.replace('#', '');
+  const anchor = document.getElementById(anchorId);
+  window.scrollTo({
+    top: anchor.offsetTop,
+    behavior: 'smooth',
+  });
+}

--- a/svelte-kit-scss/src/lib/helpers/index.ts
+++ b/svelte-kit-scss/src/lib/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './relativeTimeFmt';
 export * from './gists';
 export * from './user';
 export * from './repository';
+export * from './handleAnchorClick';

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/+page.svelte
@@ -1,1 +1,32 @@
-<p>Repo view Goes Here</p>
+<script lang="ts">
+  import FileExplorerAbout from '$lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte';
+  import FileExplorerContainer from '$lib/components/FileExplorer/FileExplorerContainer/FileExplorerContainer.svelte';
+  import FileExplorerNav from '$lib/components/FileExplorer/FileExplorerNav/FileExplorerNav.svelte';
+  import FileExplorerReadme from '$lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte';
+  import type { LayoutServerData } from './$types';
+
+  export let data: LayoutServerData;
+  const { repoInfo } = data;
+  const { description, website, tags } = repoInfo;
+</script>
+
+<div class="container grid grid-cols-12 subpage">
+  <section class="col-span-9 col-sm-span-12">
+    <FileExplorerNav />
+    <FileExplorerContainer />
+  </section>
+
+  <section class="col-span-3 col-sm-span-12">
+    <FileExplorerAbout {description} {website} {tags} />
+  </section>
+
+  <section class="col-span-9">
+    <FileExplorerReadme />
+  </section>
+</div>
+
+<style lang="scss">
+  .container.subpage {
+    gap: 2rem;
+  }
+</style>


### PR DESCRIPTION
Resolves: #778 

Result: 
https://www.loom.com/share/389f28d9b7c44baa843cb0bead2e2ee9

> # Create single repo view about section
> 
> ## Background
> 
> A sub-component of the single repo page, this component focuses on the about section. It should show the user details about the repository, and any links made available to the user from that section.
> 
> ## Acceptance
> 
> - [x] About title
> - [x] repo description
> - [x] link icon and url for deployed version (if available)
> - [x] open book icon and readme title
> - [x] divider line
> 
> ## Notes
> 