### PR TITLE
[qwik-pod]:  Implement language filter functionality

### DIFF
--- a/qwik-graphql-tailwind/src/components/filter-dropdown/filter-dropdown.tsx
+++ b/qwik-graphql-tailwind/src/components/filter-dropdown/filter-dropdown.tsx
@@ -1,4 +1,4 @@
-import { $, component$, useSignal, useStore } from '@builder.io/qwik';
+import { $, component$, Slot, useSignal, useStore } from '@builder.io/qwik';
 import { CheckIcon, ChevronDownIcon, XmarkIcon } from '../icons';
 import * as styles from './filter-dropdown.classNames';
 import cn from 'classnames';
@@ -13,7 +13,7 @@ export interface FilterDropdownProps {
   name: string;
   description?: string;
   current: number | string | null;
-  items: Option[];
+  items?: Option[];
   buttonClassName?: string;
 }
 
@@ -62,13 +62,15 @@ export const FilterDropdown = component$(
                   </button>
                 </div>
               )}
-              {items.map(({ label, value }) => (
-                <div>
-                  <button type="button" name={name} className={styles.itemButton}>
-                    {value === current && <CheckIcon className={styles.itemActiveIcon} />} {label}
-                  </button>
-                </div>
-              ))}
+              {items &&
+                items.map(({ label, value }) => (
+                  <div>
+                    <button type="button" name={name} className={styles.itemButton}>
+                      {value === current && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                    </button>
+                  </div>
+                ))}
+              <Slot />
             </div>
           </nav>
         </div>

--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.classNames.ts
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.classNames.ts
@@ -7,3 +7,6 @@ export const clearBtnIconContainer =
   'p-0.5 rounded bg-gray-500 inline-flex items-center justify-center mr-2 group-hover:bg-blue-500';
 export const clearBtnIcon = 'w-3.5 h-3.5 text-white';
 export const clearBtnText = 'text-sm text-gray-500 group-hover:text-blue-500';
+export const itemButton =
+  'relative w-full text-left text-xs py-2 px-10 border-t border-gray-300 hover:bg-gray-100 capitalize';
+export const itemActiveIcon = 'inline w-4 h-4 absolute left-4';

--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
@@ -1,10 +1,11 @@
-import { $, component$ } from '@builder.io/qwik';
+import { $, component$, useContext } from '@builder.io/qwik';
 import * as styles from './repo-filters.classNames';
 import cn from 'classnames';
 import { LanguageFilter, TypeFilter, RepositoryOrderField } from './types';
 import { FilterDropdown } from '../filter-dropdown/filter-dropdown';
-import { XmarkIcon } from '../icons';
+import { XmarkIcon, CheckIcon } from '../icons';
 import { SearchInput } from '../search-input/search-input';
+import filterStore from '~/context/repo-filter';
 
 export type RepoFiltersProps = {
   languages: LanguageFilter[];
@@ -17,6 +18,7 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
     console.log('reset filters');
   });
 
+  const state = useContext(filterStore);
   // TODO: logic for this
   const isFiltersActive = false;
   const isQueryActive = false;
@@ -52,7 +54,15 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
             />
           </div>
           <div>
-            <FilterDropdown name="Language" description="Select language" current="" items={languages} />
+            <FilterDropdown name="Language" description="Select language" current="" items={languages}>
+              {languages.map(({ label, value }) => (
+                <div>
+                  <button type="button" name={'language'} className={styles.itemButton}>
+                    {value === state.language && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                  </button>
+                </div>
+              ))}
+            </FilterDropdown>
           </div>
           <div>
             <FilterDropdown

--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
@@ -54,10 +54,15 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
             />
           </div>
           <div>
-            <FilterDropdown name="Language" description="Select language" current="" items={languages}>
+            <FilterDropdown name="Language" description="Select language" current="">
               {languages.map(({ label, value }) => (
                 <div>
-                  <button type="button" name={'language'} className={styles.itemButton}>
+                  <button
+                    onClick$={() => (state.language = value)}
+                    type="button"
+                    name={'language'}
+                    className={styles.itemButton}
+                  >
                     {value === state.language && <CheckIcon className={styles.itemActiveIcon} />} {label}
                   </button>
                 </div>

--- a/qwik-graphql-tailwind/src/components/repo-filters/types.ts
+++ b/qwik-graphql-tailwind/src/components/repo-filters/types.ts
@@ -19,6 +19,10 @@ export enum TypeFilter {
   ARCHIVED = 'archived',
 }
 
+export enum DefaultLanguage {
+  default = 'all',
+}
+
 export interface LanguageFilter {
   label: string;
   value: string;

--- a/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
+++ b/qwik-graphql-tailwind/src/components/user-repos/filter-sort-functions.ts
@@ -13,3 +13,17 @@ export const repoDataFilteredBySearch = (search: string, repos: UserRepo[]): Use
     return [...acc, repo];
   }, []);
 };
+
+const matchText = (target: any, value: string): boolean => target?.match(new RegExp(value, 'i'));
+
+// Function to filter repos by language
+export const repoDataFilteredByLanguage = (language: string, defaultLanguage: string, repos: UserRepo[]) => {
+  let response = repos.slice();
+  if (repos && language && language !== defaultLanguage) {
+    response = repos.filter((repo) => matchText(repo?.primaryLanguage?.name, language));
+  } else if (language === defaultLanguage) {
+    response = repos;
+  }
+
+  return response;
+};

--- a/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
+++ b/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
@@ -9,12 +9,15 @@ import { Pagination } from '../pagination/pagination';
 import { RepoFilters } from '../repo-filters/repo-filters';
 import { getLanguages } from './getLanguages';
 import filterStore from '~/context/repo-filter';
-import { repoDataFilteredBySearch } from './filter-sort-functions';
+import { repoDataFilteredByLanguage, repoDataFilteredBySearch } from './filter-sort-functions';
+import { DefaultLanguage } from '../repo-filters/types';
 
 export const UserRepos = component$(({ repos, owner }: UserReposProps) => {
   const languages = getLanguages(repos.nodes);
 
   const searchValue = useContext(filterStore);
+
+  const languageFilter = repoDataFilteredByLanguage(searchValue?.language, DefaultLanguage.default, repos.nodes);
 
   const filteredAndSortedRepos = ((): UserRepo[] => {
     const searchResponse = repoDataFilteredBySearch(searchValue?.search || '', repos.nodes);
@@ -24,7 +27,7 @@ export const UserRepos = component$(({ repos, owner }: UserReposProps) => {
   return (
     <>
       <RepoFilters languages={languages} resultCount={repos.nodes.length} />
-      {filteredAndSortedRepos.map(
+      {languageFilter.map(
         ({ id, name, description, stargazerCount, forkCount, primaryLanguage, updatedAt, isPrivate }) => (
           <div key={id} className={styles.container}>
             <div className={styles.content}>

--- a/qwik-graphql-tailwind/src/routes/[user]/index.tsx
+++ b/qwik-graphql-tailwind/src/routes/[user]/index.tsx
@@ -9,6 +9,7 @@ import { UserProfileCard } from '../../components/user-profile-card/user-profile
 import ProfileNav from '../../components/profile-nav/profile-nav';
 import { UserRepos } from '../../components/user-repos/user-repos';
 import filterStore, { FilterStoreProps } from '~/context/repo-filter';
+import { DefaultLanguage } from '~/components/repo-filters/types';
 
 interface UserStore {
   user: User | null;
@@ -28,7 +29,7 @@ export default component$(() => {
 
   const filterState = useStore<FilterStoreProps>({
     search: '',
-    language: '',
+    language: DefaultLanguage.default,
     sortType: '',
     order: '',
   });


### PR DESCRIPTION
# Implement language filter functionality

## Background

In another ticket, a component was created with the language dropdown button. The purpose of this ticket is to add the functionality and populate the fields for that button. The options that should be available to the user are listed below - when a user selects an option, the repository list on the page should be filtered to only include ones that match the user’s selection.

## Acceptance

- [x] when an option is selected, will filter the current results based on the selected option
- [x] language options should show all (default) and list of languages from users’ repos
- [x] only one selection allowed, noted with a check mark icon

## Notes



![Screenshot 2022-11-03 at 12 32 41](https://user-images.githubusercontent.com/28502531/199713078-0024e474-7f7d-4254-bccc-b8bc4f86833d.jpg)
![Screenshot 2022-11-03 at 12 32 48](https://user-images.githubusercontent.com/28502531/199713097-3bf13823-91a9-40ca-b849-65e5ea173747.jpg)
