### PR TITLE
feat(qwik) - Implement search text filter text

### DIFF
--- a/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
+++ b/qwik-graphql-tailwind/src/components/repo-filters/repo-filters.tsx
@@ -1,7 +1,7 @@
 import { $, component$, useContext } from '@builder.io/qwik';
 import * as styles from './repo-filters.classNames';
 import cn from 'classnames';
-import { LanguageFilter, TypeFilter, RepositoryOrderField } from './types';
+import { LanguageFilter, TypeFilter, RepositoryOrderField, DefaultLanguage } from './types';
 import { FilterDropdown } from '../filter-dropdown/filter-dropdown';
 import { XmarkIcon, CheckIcon } from '../icons';
 import { SearchInput } from '../search-input/search-input';
@@ -13,17 +13,16 @@ export type RepoFiltersProps = {
 };
 
 export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersProps) => {
+  const filters = useContext(filterStore);
   const resetFilters$ = $(() => {
-    // TODO: logic for reset filters
-    console.log('reset filters');
+    filters.search = '';
+    filters.language = DefaultLanguage.default;
+    (filters.type = TypeFilter.ALL), (filters.sortBy = RepositoryOrderField.UpdatedAt);
   });
-
-  const store = useContext(filterStore);
-  // TODO: logic for this
-  const isFiltersActive = false;
-  const isQueryActive = false;
-  const isTypeActive = false;
-  const isLanguageActive = false;
+  const isLanguageActive = filters.language !== TypeFilter.ALL;
+  const isQueryActive = !!filters.search;
+  const isTypeActive = filters.type !== TypeFilter.ALL;
+  const isFiltersActive = isLanguageActive || isQueryActive || isTypeActive;
 
   const sortOptions = [
     {
@@ -61,12 +60,12 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
               {filteOptions.map(({ label, value }) => (
                 <div>
                   <button
-                    onClick$={() => (store.filterType = value)}
+                    onClick$={() => (filters.type = value)}
                     type="button"
                     name={'Type'}
                     className={styles.itemButton}
                   >
-                    {value === store.filterType && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                    {value === filters.type && <CheckIcon className={styles.itemActiveIcon} />} {label}
                   </button>
                 </div>
               ))}
@@ -77,12 +76,12 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
               {languages.map(({ label, value }) => (
                 <div>
                   <button
-                    onClick$={() => (store.language = value)}
+                    onClick$={() => (filters.language = value)}
                     type="button"
                     name={'language'}
                     className={styles.itemButton}
                   >
-                    {value === store.language && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                    {value === filters.language && <CheckIcon className={styles.itemActiveIcon} />} {label}
                   </button>
                 </div>
               ))}
@@ -93,12 +92,12 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
               {sortOptions.map(({ label, value }) => (
                 <div>
                   <button
-                    onClick$={() => (store.sortBy = value)}
+                    onClick$={() => (filters.sortBy = value)}
                     type="button"
                     name={'order'}
                     className={styles.itemButton}
                   >
-                    {value === store.sortBy && <CheckIcon className={styles.itemActiveIcon} />} {label}
+                    {value === filters.sortBy && <CheckIcon className={styles.itemActiveIcon} />} {label}
                   </button>
                 </div>
               ))}
@@ -112,18 +111,18 @@ export const RepoFilters = component$(({ languages, resultCount }: RepoFiltersPr
             <span className="font-semibold" data-testid="filterText">
               {resultCount}
             </span>{' '}
-            results for {isTypeActive && <span className="font-semibold">[ current value (TBD) ]</span>} repositories{' '}
+            results for {isTypeActive && <span className="font-semibold">{filters.type}</span>} repositories{' '}
             {isQueryActive && (
               <>
-                matching <span className="font-semibold">[ current value (TBD) ]</span>
+                matching <span className="font-semibold">{filters.search}</span>
               </>
             )}{' '}
             {isLanguageActive && (
               <>
-                written in <span className="font-semibold capitalize">[ current value (TBD) ]</span>
+                written in <span className="font-semibold capitalize">{filters.language}</span>
               </>
             )}{' '}
-            sorted by <span className="font-semibold">[ current value (TBD) ]</span>
+            sorted by <span className="font-semibold">{filters.sortBy.split('_').join(' ').toLowerCase()}.</span>
           </div>
           <div>
             <button onClick$={resetFilters$} className={cn(styles.clearBtn, 'group')}>

--- a/qwik-graphql-tailwind/src/components/search-input/search-input.tsx
+++ b/qwik-graphql-tailwind/src/components/search-input/search-input.tsx
@@ -17,6 +17,7 @@ export const SearchInput = component$(({ placeholder, className }: SearchInputPr
       type="search"
       name="search"
       id="search"
+      value={searchValue.search}
       className={cn(styles.input, className)}
       placeholder={placeholder}
       onInput$={handleInput$}

--- a/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
+++ b/qwik-graphql-tailwind/src/components/user-repos/user-repos.tsx
@@ -19,56 +19,61 @@ import {
 export const UserRepos = component$(({ repos, owner }: UserReposProps) => {
   const languages = getLanguages(repos.nodes);
 
-  const store = useContext(filterStore);
-
-  const languageFilter = repoDataFilteredByLanguage(store?.language, repos.nodes);
-  const filterByType = repoDataFilteredByType(store.filterType, repos.nodes);
-  const sortedData = sortedRepoData(store?.sortBy, repos.nodes);
+  const filters = useContext(filterStore);
 
   const filteredAndSortedRepos = ((): UserRepo[] => {
-    const searchResponse = repoDataFilteredBySearch(store?.search || '', repos.nodes);
-    /**
-     * TODO:
-     * filter by type from the search response
-     *
-     * the response from filter by type to filter by language
-     *
-     * then finaly sort them
-     *
-     * then return a response
-     */
+    let searchResponse: UserRepo[] = repos.nodes;
+
+    if (filters.search) {
+      searchResponse = repoDataFilteredBySearch(filters?.search || '', searchResponse);
+    }
+
+    if (filters.language) {
+      searchResponse = repoDataFilteredByLanguage(filters?.language, searchResponse);
+    }
+
+    if (filters.type) {
+      searchResponse = repoDataFilteredByType(filters.type, searchResponse);
+    }
+
+    if (filters.sortBy) {
+      searchResponse = sortedRepoData(filters.sortBy, searchResponse);
+    }
+
     return searchResponse;
   })();
 
   return (
     <>
-      <RepoFilters languages={languages} resultCount={repos.nodes.length} />
-      {sortedData.map(({ id, name, description, stargazerCount, forkCount, primaryLanguage, updatedAt, isPrivate }) => (
-        <div key={id} className={styles.container}>
-          <div className={styles.content}>
-            <h3 className="mb-2">
-              <Link href={`/${owner}/${name}`} className={styles.headingLink}>
-                {name}
-              </Link>
-              <PrivacyBadge isPrivate={isPrivate} className="relative bottom-0.5" />
-            </h3>
-            <div className={styles.description}>{description}</div>
-            <RepoMeta
-              language={primaryLanguage?.name}
-              languageColor={primaryLanguage?.color}
-              forkCount={forkCount}
-              stargazerCount={stargazerCount}
-              updatedAt={updatedAt}
-            />
+      <RepoFilters languages={languages} resultCount={filteredAndSortedRepos.length} />
+      {filteredAndSortedRepos.map(
+        ({ id, name, description, stargazerCount, forkCount, primaryLanguage, updatedAt, isPrivate }) => (
+          <div key={id} className={styles.container}>
+            <div className={styles.content}>
+              <h3 className="mb-2">
+                <Link href={`/${owner}/${name}`} className={styles.headingLink}>
+                  {name}
+                </Link>
+                <PrivacyBadge isPrivate={isPrivate} className="relative bottom-0.5" />
+              </h3>
+              <div className={styles.description}>{description}</div>
+              <RepoMeta
+                language={primaryLanguage?.name}
+                languageColor={primaryLanguage?.color}
+                forkCount={forkCount}
+                stargazerCount={stargazerCount}
+                updatedAt={updatedAt}
+              />
+            </div>
+            <div className={styles.aside}>
+              <button className={styles.starBtn}>
+                <StarIcon className={styles.starIcon} />
+                Star
+              </button>
+            </div>
           </div>
-          <div className={styles.aside}>
-            <button className={styles.starBtn}>
-              <StarIcon className={styles.starIcon} />
-              Star
-            </button>
-          </div>
-        </div>
-      ))}
+        )
+      )}
       {(repos.pageInfo?.hasNextPage || repos.pageInfo?.hasPreviousPage) && (
         <Pagination pageInfo={repos.pageInfo} owner={owner} />
       )}

--- a/qwik-graphql-tailwind/src/context/repo-filter.ts
+++ b/qwik-graphql-tailwind/src/context/repo-filter.ts
@@ -2,7 +2,7 @@ import { createContext } from '@builder.io/qwik';
 export interface FilterStoreProps {
   search: string;
   language: string;
-  filterType: string;
+  type: string;
   sortBy: string;
 }
 const filterStore = createContext<FilterStoreProps>('filter-context');

--- a/qwik-graphql-tailwind/src/routes/[user]/index.tsx
+++ b/qwik-graphql-tailwind/src/routes/[user]/index.tsx
@@ -30,7 +30,7 @@ export default component$(() => {
   const filterState = useStore<FilterStoreProps>({
     search: '',
     language: DefaultLanguage.default,
-    filterType: TypeFilter.ALL,
+    type: TypeFilter.ALL,
     sortBy: RepositoryOrderField.UpdatedAt,
   });
 


### PR DESCRIPTION
 ##Acceptance Criteria

Closes: #771  

- [x]  Below the search bar and above results, should see text related to the current options text will update based on which options are active
- [x]  search: “{number} results for repositories matching {query} sorted by {sort}”
- [x]  type filter: “{number} results for {type} repositories sorted by {sort}”
- [x] [ ] language filter: “{number} results for repositories written in {language} sorted by {sort}”
- [x]  all options: “{number} results for {type} repositories matching {query} written in {language} sorted by {sort}”
- [x]  sort selection by itself does not show any text - however when any other option is selected, it will show the correct active sort value

- [x]  if search or type / language filter options are selected, will always show “X clear filter” text on the right hand side, which will reset all values to default when clicked

## Preview

![image](https://user-images.githubusercontent.com/14813235/199758808-fde9c8a9-caa1-417a-a76a-3f9710612c8b.png)
