### PR TITLE
[sveltekit-pod] 34 Add logout functionality

### DIFF
--- a/svelte-kit-scss/src/hooks.server.ts
+++ b/svelte-kit-scss/src/hooks.server.ts
@@ -14,8 +14,14 @@ export const handle: Handle = async ({ event, resolve }) => {
     }
   }
 
+  if (event.url.pathname.startsWith('/signin')) {
+    if (accessTokenFromCookies) {
+      return Response.redirect(`${event.url.origin}`);
+    }
+  }
+
   // erase token cookie
-  if (event.url.pathname === '/signin') {
+  if (event.url.pathname === '/logout') {
     event.cookies.set(AUTH_COOKIE_NAME, String(), AUTH_COOKIE_ERASE_OPTIONS);
     event.locals.accessToken = undefined;
     event.locals.user = undefined;

--- a/svelte-kit-scss/src/lib/components/NavBar/NavBar.svelte
+++ b/svelte-kit-scss/src/lib/components/NavBar/NavBar.svelte
@@ -18,7 +18,7 @@
 
   function signOut() {
     closeDropdown();
-    location.href = '/signin';
+    location.href = '/logout';
   }
 
   onMount(() => {

--- a/svelte-kit-scss/src/lib/services/auth-service.ts
+++ b/svelte-kit-scss/src/lib/services/auth-service.ts
@@ -25,7 +25,7 @@ export class AuthService {
   }
 
   signOut(): void {
-    goto('/signin');
+    goto('/logout');
   }
 
   /**

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/+page.svelte
@@ -8,7 +8,7 @@
   import OrgInfo from '$lib/components/Profile/OrgInfo/OrgInfo.svelte';
   import type { RepoFiltersState } from '$lib/components/shared/RepoControls/repo-filters-state';
   import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';
-  
+
   export let data: PageServerData;
 
   // sample:

--- a/svelte-kit-scss/src/routes/logout/+page.server.ts
+++ b/svelte-kit-scss/src/routes/logout/+page.server.ts
@@ -1,0 +1,21 @@
+import { redirect } from '@sveltejs/kit';
+import { AUTH_COOKIE_ERASE_OPTIONS, AUTH_COOKIE_NAME } from '$lib/constants/auth';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  // we only use this endpoint for the api
+  // and don't need to see the page
+  throw redirect(302, '/');
+};
+
+export const actions: Actions = {
+  default({ cookies, locals }) {
+    // eat the cookie
+    cookies.set(AUTH_COOKIE_NAME, String(), AUTH_COOKIE_ERASE_OPTIONS);
+    locals.accessToken = undefined;
+    locals.user = undefined;
+
+    // redirect the user
+    throw redirect(302, '/signin');
+  },
+};


### PR DESCRIPTION
Resolves: #783

> # Add logout functionality
> 
> ## Background
> 
> As a user, if I click the sign out link in the header, I am signed out of the application and redirected to the sign in screen. 
> 
> ## Acceptance
> 
> - [x] connect header / nav bar button to `/logout` route
> - [x] when clicked, clear user authentication from storage
> - [x] redirect to login page on success
> 
> ## Notes
> 
> Ensure the user’s access token cookie is cleared, and any information in any state storage is cleared as well.

