### PR TITLE
[solidjs-pod]  Get all repositories from GitHub API#684

### DIFF
--- a/solidjs-tailwind/src/services/api.js
+++ b/solidjs-tailwind/src/services/api.js
@@ -1,0 +1,25 @@
+const FetchApi = ({url, query, variables, headersOptions}) => {
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      method: "POST",
+      headers: {
+        ...headersOptions,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        variables
+      })
+    })
+    .then((res) => res.json())
+      .then((result) => {
+        resolve(result);
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+};
+
+export default FetchApi;

--- a/solidjs-tailwind/src/services/api.js
+++ b/solidjs-tailwind/src/services/api.js
@@ -1,7 +1,7 @@
-const FetchApi = ({url, query, variables, headersOptions}) => {
+const FetchApi = ({ url, query, variables, headersOptions }) => {
   return new Promise((resolve, reject) => {
     fetch(url, {
-      method: "POST",
+      method: 'POST',
       headers: {
         ...headersOptions,
         Accept: 'application/vnd.github+json',
@@ -9,10 +9,10 @@ const FetchApi = ({url, query, variables, headersOptions}) => {
       },
       body: JSON.stringify({
         query,
-        variables
-      })
+        variables,
+      }),
     })
-    .then((res) => res.json())
+      .then((res) => res.json())
       .then((result) => {
         resolve(result);
       })

--- a/solidjs-tailwind/src/services/queries/all-repos.js
+++ b/solidjs-tailwind/src/services/queries/all-repos.js
@@ -1,0 +1,55 @@
+export const USER_REPOS_QUERY = `
+  query UserRepos(
+    $username: String!
+    $afterCursor: String
+    $beforeCursor: String
+    $orderBy: RepositoryOrder
+    $first: Int
+    $last: Int
+  ) {
+    owner: user(login: $username) {
+      repositories(
+        first: $first
+        last: $last
+        after: $afterCursor
+        before: $beforeCursor
+        orderBy: $orderBy
+        ownerAffiliations: [OWNER]
+      ) {
+        nodes {
+          id
+          name
+          description
+          stargazerCount
+          forkCount
+          isArchived
+          isFork
+          primaryLanguage {
+            id
+            color
+            name
+          }
+          languages(first: 10, orderBy: { direction: ASC, field: SIZE }) {
+            nodes {
+              color
+              name
+              id
+            }
+          }
+          isPrivate
+          visibility
+          updatedAt
+          owner {
+            login
+          }
+        }
+        pageInfo {
+          endCursor
+          startCursor
+          hasNextPage
+          hasPreviousPage
+        }
+      }
+    }
+  }
+`;

--- a/solidjs-tailwind/src/services/user-repos.js
+++ b/solidjs-tailwind/src/services/user-repos.js
@@ -1,0 +1,50 @@
+import FetchApi from "./api";
+import { USER_REPOS_QUERY } from "./queries/all-repos";
+
+const getUserRepos = async ({
+  url
+}) => {
+  const data = {
+    url,
+    query: USER_REPOS_QUERY,
+    variable: null,
+    headersOptions: {
+      authorization: `Bearer tokenvalue`,
+    }
+  }
+  const resp = await FetchApi(data);
+   const nodes = resp?.owner?.repositories?.nodes;
+   const pageInfo = resp?.owner?.repositories?.pageInfo;
+
+  if (!nodes) {
+    return undefined;
+  }
+  const repos = nodes?.reduce((acc, repo) => {
+        return repo
+          ? [
+              ...acc,
+              {
+                id: repo.id,
+                name: repo.name,
+                description: repo.description,
+                stargazerCount: repo.stargazerCount,
+                forkCount: repo.forkCount,
+                primaryLanguage: {
+                  name: repo.primaryLanguage?.name,
+                  color: repo.primaryLanguage?.color,
+                },
+                visibility: repo.visibility,
+                updatedAt: repo.updatedAt,
+                owner: repo.owner,
+              },
+            ]
+          : acc;
+  }, []);
+
+  return {
+    pageInfo,
+    repos
+  };
+};
+
+export default getUserRepos;


### PR DESCRIPTION
# Get all repositories from GitHub API

## Background

On a user’s profile page, we want to list out ALL of their repositories - not just the top ones. This ticket will be to get the data on all of a user’s repos for display on the profile page. 

## Acceptance

- [x] Get all repositories from GitHub API
- [x] For display on profile page; data needed:
    - [x] Repo name
    - [x] description
    - [x] language
    - [x] star count
    - [x] fork count
    - [x] last updated
    - [x] visibility tag

## Notes

- This query should start sorted by most recently updated.

