### PR TITLE
[qwik-pod] : Get pull request information from GitHub API

### DIFF
--- a/qwik-graphql-tailwind/src/routes/[owner]/[name]/index.tsx
+++ b/qwik-graphql-tailwind/src/routes/[owner]/[name]/index.tsx
@@ -10,6 +10,7 @@ import { RepoAboutWidget } from '~/components/repo-about';
 import { ISSUES_QUERY } from '~/utils/queries/issues-query';
 import { RepoHeader } from '~/components/repo-header';
 import { BranchNavigation } from '~/components/branch-navigation';
+import { PULL_REQUEST_QUERY } from '~/utils/queries/pull-request';
 
 export interface SharedState {
   name: string;
@@ -47,7 +48,7 @@ export interface SharedState {
   };
 }
 
-interface IssuesQueryParams {
+interface IssuesPullRequestsQueryParams {
   owner: string;
   name: string;
   first: number;
@@ -173,10 +174,33 @@ export async function fetchRepoInfo(
 }
 
 export async function fetchIssues(
-  { owner, name, first }: IssuesQueryParams,
+  { owner, name, first }: IssuesPullRequestsQueryParams,
   abortController?: AbortController
 ): Promise<any> {
   const { executeQuery$ } = useQuery(ISSUES_QUERY);
+
+  const resp = await executeQuery$({
+    signal: abortController?.signal,
+    url: GITHUB_GRAPHQL,
+    variables: {
+      owner,
+      name,
+      first,
+    },
+    headersOpt: {
+      Accept: 'application/vnd.github+json',
+      authorization: `Bearer ${sessionStorage.getItem('token')}`,
+    },
+  });
+
+  return await resp.json();
+}
+
+export async function fetchPullRequests(
+  { owner, name, first }: IssuesPullRequestsQueryParams,
+  abortController?: AbortController
+): Promise<any> {
+  const { executeQuery$ } = useQuery(PULL_REQUEST_QUERY);
 
   const resp = await executeQuery$({
     signal: abortController?.signal,

--- a/qwik-graphql-tailwind/src/utils/queries/pull-request.ts
+++ b/qwik-graphql-tailwind/src/utils/queries/pull-request.ts
@@ -1,0 +1,44 @@
+export const PULL_REQUEST_QUERY = `
+  query PullRequests($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      openPullRequest: pullRequests(first: $first, states: [OPEN]) {
+        edges {
+          node {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            headRefName
+            title
+            url
+          }
+        }
+      }
+      closedPullRequest: pullRequests(first: $first, states: [CLOSED, MERGED]) {
+        edges {
+          node {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            headRefName
+            title
+            url
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Get pull request information from GitHub API

## Background

On the single repo page, we’ll have a tab for viewing open and closed pull requests. We do not (currently) have the functionality to click into the PRs, so this ticket will be for creating the initial view that mostly concerns the name of the PR and some metadata about each one.
closes #853 
## Acceptance

- [x] Get repository pull requests from GitHub API
- [x] For display in pull request tab on single repository page; data needed:
    - [x] name of PR
    - [x] PR number
    - [x] name of person who created it
    - [x] created / closed date
    - [x] number of comments

## Notes