### PR TITLE
[sveltekit-pod] 30 Create single repo issues tab view

### DIFF
--- a/svelte-kit-scss/src/lib/components/IssueHeader/IssueHeader.svelte
+++ b/svelte-kit-scss/src/lib/components/IssueHeader/IssueHeader.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import { Check16, NoEntry16 } from 'svelte-octicons';
+  import type { PR_STATE, RepoIssue } from '$lib/interfaces';
+  import FilterDropdown from '$lib/components/shared/FilterDropdown/FilterDropdown.svelte';
+  import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';
+  import { createEventDispatcher } from 'svelte';
+
+  export let openIssues: RepoIssue | undefined,
+    closedIssues: RepoIssue | undefined,
+    viewState: PR_STATE;
+
+  export let labelFilters: FilterDropdownOption[] = [];
+  export let milestoneFilters: FilterDropdownOption[] = [];
+  export let sortFilters: FilterDropdownOption[] = [];
+
+  interface IssueFiltersState {
+    label?: FilterDropdownOption;
+    milestone?: FilterDropdownOption;
+    sort?: FilterDropdownOption;
+  }
+
+  const defaultFilters: IssueFiltersState = {
+    label: labelFilters[0],
+    milestone: milestoneFilters[0],
+    sort: sortFilters[0],
+  };
+
+  const currentFilters = {
+    label: defaultFilters.label,
+    milestone: defaultFilters.milestone,
+    sort: defaultFilters.sort,
+  };
+
+  $: hasActiveFilters =
+    currentFilters.label !== defaultFilters.label || currentFilters.sort !== defaultFilters.sort;
+
+  const dispatch = createEventDispatcher();
+
+  const dispatchFiltersChange = () => {
+    dispatch('filtersChange', currentFilters);
+  };
+
+  const handleLabelFilterChange = (event: CustomEvent<FilterDropdownOption>): void => {
+    currentFilters.label = event.detail;
+    dispatchFiltersChange();
+  };
+  const handleMilestoneFilterChange = (event: CustomEvent<FilterDropdownOption>): void => {
+    currentFilters.milestone = event.detail;
+    dispatchFiltersChange();
+  };
+  const handleSortFilterChange = (event: CustomEvent<FilterDropdownOption>): void => {
+    currentFilters.sort = event.detail;
+    dispatchFiltersChange();
+  };
+</script>
+
+<div class="filters-container">
+  <div class="pull-requests-status">
+    <button
+      class="tab-button"
+      class:active={viewState === 'open'}
+      on:click={() => (viewState = 'open')}
+    >
+      <span class="icon">
+        <NoEntry16 />
+      </span>
+      <span>{openIssues?.totalCount ?? 0} Open</span>
+    </button>
+    <button
+      class="tab-button"
+      class:active={viewState === 'closed'}
+      on:click={() => (viewState = 'closed')}
+    >
+      <span class="icon">
+        <Check16 />
+      </span><span>{closedIssues?.totalCount ?? 0} closed</span>
+    </button>
+  </div>
+  <div class="pull-requests-filters">
+    <FilterDropdown
+      name="Label"
+      description="Filter by label"
+      items={labelFilters}
+      defaultFilter={defaultFilters.label}
+      on:setFilter={handleLabelFilterChange}
+      borderNone={true}
+    />
+    <FilterDropdown
+      name="Milestone"
+      description="Filter by Milestone"
+      items={milestoneFilters}
+      defaultFilter={defaultFilters.milestone}
+      on:setFilter={handleMilestoneFilterChange}
+      borderNone={true}
+    />
+    <FilterDropdown
+      name="Sort"
+      description="Sort by"
+      items={sortFilters}
+      defaultFilter={defaultFilters.sort}
+      on:setFilter={handleSortFilterChange}
+      borderNone={true}
+    />
+  </div>
+</div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+
+  .filters-container {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 1rem;
+    background-color: variables.$gray100;
+
+    @media (min-width: variables.$md) {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .pull-requests-status {
+      display: flex;
+      align-items: center;
+      font-weight: 600;
+      gap: 1rem;
+      color: variables.$gray600;
+
+      .tab-button {
+        color: inherit;
+        display: flex;
+        border: none;
+        align-items: center;
+        cursor: pointer;
+        background: inherit;
+
+        .icon {
+          margin-right: 0.375rem;
+        }
+
+        &.active {
+          color: variables.$gray900;
+          font-weight: 600;
+        }
+      }
+    }
+
+    .pull-requests-filters {
+      display: flex;
+      align-items: center;
+      gap: 0.875rem;
+      @media (max-width: variables.$md) {
+        margin-top: 0.875rem;
+      }
+    }
+  }
+</style>

--- a/svelte-kit-scss/src/lib/components/IssueHeader/IssueHeader.svelte
+++ b/svelte-kit-scss/src/lib/components/IssueHeader/IssueHeader.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Check16, NoEntry16 } from 'svelte-octicons';
-  import type { PR_STATE, RepoIssue } from '$lib/interfaces';
+  import type { PR_STATE, RepoIssues } from '$lib/interfaces';
   import FilterDropdown from '$lib/components/shared/FilterDropdown/FilterDropdown.svelte';
   import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';
   import { createEventDispatcher } from 'svelte';
 
-  export let openIssues: RepoIssue | undefined,
-    closedIssues: RepoIssue | undefined,
+  export let openIssues: RepoIssues | undefined,
+    closedIssues: RepoIssues | undefined,
     viewState: PR_STATE;
 
   export let labelFilters: FilterDropdownOption[] = [];

--- a/svelte-kit-scss/src/lib/components/IssuesList/IssuesList.svelte
+++ b/svelte-kit-scss/src/lib/components/IssuesList/IssuesList.svelte
@@ -18,3 +18,15 @@
     {/if}
   </div>
 </div>
+
+<style lang="scss">
+  @use 'src/lib/styles/variables.scss';
+
+  .empty-list {
+    display: flex;
+    height: 10rem;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+  }
+</style>

--- a/svelte-kit-scss/src/lib/helpers/issues.ts
+++ b/svelte-kit-scss/src/lib/helpers/issues.ts
@@ -1,4 +1,9 @@
-import type { PullRequestItemAPIResponse, RepoIssue } from '$lib/interfaces';
+import type {
+  IssuesAPIResponse,
+  PullRequestItemAPIResponse,
+  RepoIssue,
+  RepoIssues,
+} from '$lib/interfaces';
 
 export const remapRepoIssue = (item: PullRequestItemAPIResponse): RepoIssue => {
   return {
@@ -12,5 +17,12 @@ export const remapRepoIssue = (item: PullRequestItemAPIResponse): RepoIssue => {
     labels: item.labels,
     commentCount: item.comments,
     labelCount: item.labels?.length || 0,
+  };
+};
+
+export const remapRepoIssueCollection = (data: IssuesAPIResponse): RepoIssues => {
+  return {
+    totalCount: data.total_count,
+    issues: data.items.map(remapRepoIssue).filter(Boolean) as RepoIssue[],
   };
 };

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.server.ts
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.server.ts
@@ -1,7 +1,7 @@
 import type { PageServerLoad } from './$types';
-import { remapRepoIssue } from '$lib/helpers';
+import { remapRepoIssueCollection } from '$lib/helpers';
 import { ENV } from '$lib/constants/env';
-import type { IssuesAPIResponse, RepoIssue } from '$lib/interfaces';
+import type { IssuesAPIResponse } from '$lib/interfaces';
 
 export const load: PageServerLoad = async ({ fetch, params }) => {
   const { username, repo } = params;
@@ -22,8 +22,8 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
       ),
     ]);
     return {
-      openIssues: openIssues.items.map(remapRepoIssue).filter(Boolean) as RepoIssue[],
-      closedIssues: closedIssues.items.map(remapRepoIssue).filter(Boolean) as RepoIssue[],
+      openIssues: remapRepoIssueCollection(openIssues),
+      closedIssues: remapRepoIssueCollection(closedIssues),
     };
   } catch (err) {
     // TODO: investigate better ways to handle and prompt users on errors

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.svelte
@@ -1,20 +1,76 @@
 <script lang="ts">
   import type { PageServerData } from './$types';
   import IssuesList from '$lib/components/IssuesList/IssuesList.svelte';
+  import IssueHeader from '$lib/components/IssueHeader/IssueHeader.svelte';
+  import Pagination from '$lib/components/shared/Pagination/Pagination.svelte';
+  import type { PR_STATE } from '$lib/interfaces';
+  import type { FilterDropdownOption } from '$lib/components/shared/FilterDropdown/filter-option';
 
   export let data: PageServerData;
 
   const { openIssues, closedIssues } = data;
 
-  let viewState = 'open';
+  const sortFilters: FilterDropdownOption<any>[] = [
+    {
+      label: 'Dummy 1',
+      value: 'dummy-1',
+    },
+    {
+      label: 'Dummy 2',
+      value: 'dummy-2',
+    },
+    {
+      label: 'Dummy 3',
+      value: 'dummy-3',
+    },
+  ];
+
+  const milestoneFilters: FilterDropdownOption<any>[] = [
+    {
+      label: 'Dummy 1',
+      value: 'dummy-1',
+    },
+    {
+      label: 'Dummy 2',
+      value: 'dummy-2',
+    },
+    {
+      label: 'Dummy 3',
+      value: 'dummy-3',
+    },
+  ];
+
+  const labelFilters: FilterDropdownOption<any>[] = [
+    {
+      label: 'Dummy 1',
+      value: 'dummy-1',
+    },
+    {
+      label: 'Dummy 2',
+      value: 'dummy-2',
+    },
+    {
+      label: 'Dummy 3',
+      value: 'dummy-3',
+    },
+  ];
+
+  let viewState: PR_STATE = 'open';
 </script>
 
 <div class="container">
-  <span> header should go here </span>
   <div class="issues-container">
-    <IssuesList issues={viewState === 'open' ? openIssues : closedIssues} />
+    <IssueHeader
+      {openIssues}
+      {closedIssues}
+      {labelFilters}
+      {milestoneFilters}
+      {sortFilters}
+      bind:viewState
+    />
+    <IssuesList issues={viewState === 'open' ? openIssues.issues : closedIssues.issues} />
   </div>
-  <span> Pagination should go here </span>
+  <Pagination />
 </div>
 
 <style lang="scss">

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/issues/+page.svelte
@@ -68,7 +68,7 @@
       {sortFilters}
       bind:viewState
     />
-    <IssuesList issues={viewState === 'open' ? openIssues.issues : closedIssues.issues} />
+    <IssuesList issues={viewState === 'open' ? openIssues?.issues : closedIssues?.issues} />
   </div>
   <Pagination />
 </div>


### PR DESCRIPTION
Resolves #859

# Create single repo issues tab view

## Background

As a user, if I click into the issues tab for a repository, I can see a list of cards containing information about issues for this repo. By default I land on the view for open issues, and can click on the words “open” or “closed” to change if I see currently open or closed issues. 

## Acceptance

- [x] section header shows:
    - [x] {number} open with icon
    - [x] {number} closed with icon
    - [x] label dropdown (does not need options)
    - [x] milestones dropdown (does not need options)
    - [x] sort dropdown (does not need options)
- [x] body shows either open or closed (depending on which is selected) issue cards
- [x] pagination navigation - < prev next > (does not need to function yet)

## Notes

