### PR TITLE
Solid/get org repos api

### DIFF
--- a/solidjs-tailwind/src/services/get-org-repos.js
+++ b/solidjs-tailwind/src/services/get-org-repos.js
@@ -1,0 +1,26 @@
+import FetchApi from './api';
+import { useAuth } from '../auth';
+import { ORGANIZATION_REPOS_QUERY } from './queries/org-repos';
+
+/**
+ * @param {string} url
+ * @param {Object} variable: {organization, first}
+ *
+ */
+
+const getOrgRepos = async ({ url, variable }) => {
+  const { authStore } = useAuth();
+
+  const data = {
+    url,
+    query: ORGANIZATION_REPOS_QUERY,
+    variable,
+    headersOptions: {
+      authorization: `Bearer ${authStore.token}`,
+    },
+  };
+  const resp = await FetchApi(data);
+  return resp.organization;
+};
+
+export default getOrgRepos;

--- a/solidjs-tailwind/src/services/queries/org-repos.js
+++ b/solidjs-tailwind/src/services/queries/org-repos.js
@@ -1,0 +1,24 @@
+export const ORGANIZATION_REPOS_QUERY = `
+  query OrganizationRepos($organization: String!, $first: Int!) {
+    organization(login: $organization) {
+      repositories(first: $first) {
+        edges {
+          node {
+            name
+            description
+            url
+            forkCount
+            stargazerCount
+            primaryLanguage {
+              color
+              name
+              id
+            }
+            updatedAt
+            visibility
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Get Organization repositories from GitHub API

## Background

There will be a view for an organization’s profile, which, similar to the user’s profile, will list all of the organization’s repositories.

## Acceptance

- [x] Get organization repositories from GitHub API
- [x] For display on organization page; data needed:
    - [x] Repo name
    - [x] description
    - [x] language
    - [x] star count
    - [x] fork count
    - [x] last updated
    - [x] visibility tag

## Notes

- This query should start sorted by most recently updated.
