### PR TITLE
feat(solid-kit): Get issue information from GitHub API

### DIFF
--- a/solidjs-tailwind/src/services/get-issues.js
+++ b/solidjs-tailwind/src/services/get-issues.js
@@ -1,0 +1,25 @@
+import FetchApi from './api';
+import { useAuth } from '../auth';
+import { ISSUES_QUERY } from './queries/issue-info';
+
+const getIssues = async ({ url, variable }) => {
+  const { authStore } = useAuth();
+
+  const data = {
+    url,
+    query: ISSUES_QUERY,
+    variable,
+    headersOptions: {
+      authorization: `Bearer ${authStore.token}`,
+    },
+  };
+  const resp = await FetchApi(data);
+  const repository = resp.repository;
+
+  return {
+    openIssues: repository?.openIssues.nodes,
+    closedIssues: repository?.closedIssues.nodes,
+  };
+};
+
+export default getIssues;

--- a/solidjs-tailwind/src/services/queries/issue-info.js
+++ b/solidjs-tailwind/src/services/queries/issue-info.js
@@ -1,0 +1,46 @@
+export const ISSUES_QUERY = `
+  query IssuesQuery($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      openIssues: issues(
+        first: $first
+        states: [OPEN]
+        orderBy: { field: CREATED_AT, direction: DESC }
+      ) {
+        nodes {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+        }
+      }
+      closedIssues: issues(
+        first: $first
+        states: [CLOSED]
+        orderBy: { field: CREATED_AT, direction: DESC }
+      ) {
+        nodes {
+            state
+            createdAt
+            closedAt
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Get issue information from GitHub API

## Background

On the single repo page, we’ll have a tab for viewing open and closed issues. We do not (currently) have the functionality to click into the issues, so this ticket will be for creating the initial view that mostly concerns the name of the issue and some metadata about each one.

## Acceptance

- [x] Get repository issues from GitHub API
- [x] For display in issues tab on single repository page; data needed:
    - [x] name of issue
    - [x] issue number
    - [x] name of person who created the issue
    - [x] created / closed date
    - [x] number of comments

## Notes

