### PR TITLE
created component for the about section

### DIFF
--- a/solidjs-tailwind/src/components/Icons/BookOpenIcon.jsx
+++ b/solidjs-tailwind/src/components/Icons/BookOpenIcon.jsx
@@ -1,0 +1,20 @@
+const BookOpenIcon = (props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      class={props.class ?? ''}
+      viewBox="0 0 24 24"
+      stroke-width={1.5}
+      stroke="currentColor"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-line-join="round"
+        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  );
+}
+
+export default BookOpenIcon;

--- a/solidjs-tailwind/src/components/Icons/index.js
+++ b/solidjs-tailwind/src/components/Icons/index.js
@@ -9,3 +9,4 @@ export { default as OfficeBuildingIcon } from './OfficeBuildingIcon';
 export { default as StarIcon } from './StarIcon';
 export { default as LocationMarkerIcon } from './LocationMarkerIcon';
 export { default as UsersIcon } from './UsersIcon';
+export { default as BookOpenIcon } from './BookOpenIcon';

--- a/solidjs-tailwind/src/components/RepoAbout/Description.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/Description.jsx
@@ -1,0 +1,13 @@
+export const Description = (props) => {
+  return (
+    <>
+      {props.text ? (
+        <span data-testid="repo file explorer description">{props.text}</span>
+      ) : (
+        <span class="italic" data-testid="repo file explorer description">
+          No description, website, or topics provided.
+        </span>
+      )}
+    </>
+  );
+};

--- a/solidjs-tailwind/src/components/RepoAbout/HomePageUrl.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/HomePageUrl.jsx
@@ -1,0 +1,18 @@
+import { Link } from '@solidjs/router';
+import { LinkIcon } from '../icons';
+import styles from './RepoAbout.module.css';
+
+export const HomepageUrl = (props) => {
+  return (
+    <>
+      {props.homepageUrl ? (
+        <div class={styles.linkContainer}>
+          <LinkIcon class={styles.linkIcon} />
+          <Link href={props.homepageUrl} class={styles.link} target="_blank">
+            {props.homepageUrl}
+          </Link>
+        </div>
+      ) : null}
+    </>
+  );
+};

--- a/solidjs-tailwind/src/components/RepoAbout/RepoAbout.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/RepoAbout.jsx
@@ -1,0 +1,25 @@
+import { BookOpenIcon } from '../icons';
+import { Description } from './Description';
+import { HomepageUrl } from './HomePageUrl';
+import { Topics } from './Topics';
+import styles from './RepoAbout.module.css';
+
+export const RepoAboutWidget = (props) => {
+  return (
+    <div class={styles.container}>
+      <h3 class={styles.heading}>About</h3>
+      <div class={styles.description}>
+        <div class="space-y-4">
+          <Description text={props.info.data?.description} />
+          <HomepageUrl homepageUrl={props.info.data?.homepageUrl} />
+          <Topics topics={props.info.data?.topics} />
+        </div>
+      </div>
+      <div>
+        <a class={styles.readmeLink}>
+          <BookOpenIcon class={styles.readmeIcon} /> Readme
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/solidjs-tailwind/src/components/RepoAbout/RepoAbout.module.css
+++ b/solidjs-tailwind/src/components/RepoAbout/RepoAbout.module.css
@@ -1,0 +1,37 @@
+@tailwind utilities;
+
+.container {
+  @apply pb-8 space-y-5 border-b-2 border-gray-300;
+}
+
+.heading {
+  @apply text-gray-700 font-semibold;
+}
+
+.description {
+  @apply text-gray-600;
+}
+
+.readmeLink {
+  @apply flex items-center text-gray-500 hover:text-blue-500 text-sm cursor-pointer leading-snug;
+}
+
+.readmeIcon {
+  @apply h-5 w-5 mt-0.5 mr-2;
+}
+
+.linkContainer {
+  @apply max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap;
+}
+
+.linkIcon {
+  @apply w-4 h-4 inline text-gray-700 mr-2 -mt-0.5;
+}
+
+.link {
+  @apply font-semibold text-blue-600 hover:underline text-sm;
+}
+
+.topic {
+  @apply inline-block bg-blue-100 text-blue-600 text-xs font-medium py-1 px-2 rounded-xl mr-1.5 hover:text-white hover:bg-blue-600 transition-colors cursor-pointer;
+}

--- a/solidjs-tailwind/src/components/RepoAbout/RepoAbout.stories.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/RepoAbout.stories.jsx
@@ -1,0 +1,38 @@
+import { Router } from '@solidjs/router';
+import { RepoAboutWidget } from './RepoAbout';
+
+export default {
+  title: 'Components/RepoAboutWidget',
+  parameters: {
+    mockData: [
+      {
+        info: {
+            data: {
+                description: 'This is a description',
+                homepageUrl: 'https://www.google.com',
+                topics: ['topic1', 'topic2', 'topic3']
+            }
+        }
+      },
+    ],
+  },
+};
+
+const Template = (args) => (
+    <Router>
+        <RepoAboutWidget {...args} />
+    </Router>
+);
+
+export const Default = Template.bind({});
+
+
+Default.args = {
+    info: {
+        data: {
+            description: 'This is a description',
+            homepageUrl: 'https://www.google.com',
+            topics: ['topic1', 'topic2', 'topic3']
+        }
+    }
+};

--- a/solidjs-tailwind/src/components/RepoAbout/Topics.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/Topics.jsx
@@ -1,0 +1,16 @@
+import { For } from 'solid-js';
+import styles from './RepoAbout.module.css';
+
+export const Topics = (props) => {
+  return (
+    <>
+      {props.topics.length === 0 ? null : (
+        <div class="space-y-1">
+          <For each={props.topics}>
+            {(topic) => <span class={styles.topic}>{topic}</span>}
+          </For>
+        </div>
+      )}
+    </>
+  );
+};

--- a/solidjs-tailwind/src/components/RepoAbout/index.jsx
+++ b/solidjs-tailwind/src/components/RepoAbout/index.jsx
@@ -1,0 +1,1 @@
+export { default as RepoAbout } from './RepoAbout';


### PR DESCRIPTION
Closes: https://github.com/thisdot/starter.dev-github-showcases/issues/942

# Create single repo view about section

## Background

A sub-component of the single repo page, this component focuses on the about section. It should show the user details about the repository, and any links made available to the user from that section.

## Acceptance

- [x] About title
- [x] repo description
- [x] link icon and url for deployed version (if available)
- [x] open book icon and readme title
- [x] divider line

## Notes
