### PR TITLE
chore [sveltekit-pod]: disable showcase link for sveltekit

### DIFF
--- a/svelte-kit-scss/package.json
+++ b/svelte-kit-scss/package.json
@@ -6,7 +6,9 @@
     "sass"
   ],
   "private": true,
+  "hasShowcase": false,
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
     "start": "vite dev --open",
     "dev": "vite dev",
@@ -77,7 +79,6 @@
     ],
     "src/**/*{.js,.ts,.svelte}": "eslint ."
   },
-  "type": "module",
   "dependencies": {
     "cookie": "^0.5.0",
     "markdown-it": "^13.0.1",


### PR DESCRIPTION
Remove links to the showcase for the sveltekit kit, at least until the showcase is ready and deployed