### PR TITLE
feat(#961): Add Netlify to Angular Apollo Tailwind showcase

### DIFF
--- a/angular-apollo-tailwind/src/app/components/toaster/toaster.component.html
+++ b/angular-apollo-tailwind/src/app/components/toaster/toaster.component.html
@@ -1,4 +1,4 @@
-<div class="toaster position-fixed top-0 end-0 px-3 py-2 m-16">
+<div class="toaster fixed top-0 end-0 px-3 py-2 m-16">
   <div *ngFor="let toast of currentToasts; index as i">
     <app-toast [toast]="toast" (disposeEvent)="dispose(i)"></app-toast>
   </div>

--- a/angular-apollo-tailwind/src/app/home/home.component.css
+++ b/angular-apollo-tailwind/src/app/home/home.component.css
@@ -1,0 +1,3 @@
+.netlify-badge-container {
+  @apply flex justify-center mt-auto pb-5 pt-6;
+}

--- a/angular-apollo-tailwind/src/app/home/home.component.html
+++ b/angular-apollo-tailwind/src/app/home/home.component.html
@@ -1,7 +1,20 @@
-<ng-container *ngIf="user$ | async as user">
-  <app-navbar [user]="user"></app-navbar>
-</ng-container>
+<div class="h-full flex flex-col">
+  <ng-container *ngIf="user$ | async as user">
+    <app-navbar [user]="user"></app-navbar>
+  </ng-container>
 
-<router-outlet></router-outlet>
+  <div class="grow">
+    <router-outlet></router-outlet>
+  </div>
+
+  <div class="netlify-badge-container">
+    <a target="_blank" href="https://www.netlify.com">
+      <img
+        src="https://www.netlify.com/v3/img/components/netlify-light.svg"
+        alt="Deploys by Netlify"
+      />
+    </a>
+  </div>
+</div>
 
 <app-toaster></app-toaster>

--- a/angular-apollo-tailwind/src/app/provider/provider.component.css
+++ b/angular-apollo-tailwind/src/app/provider/provider.component.css
@@ -18,3 +18,7 @@
 .button {
   @apply w-full mb-3 px-4 py-3 border border-solid border-gray-500 rounded-md font-medium relative;
 }
+
+.netlify-badge-container {
+  @apply fixed bottom-5 left-0 right-0 flex justify-center;
+}

--- a/angular-apollo-tailwind/src/app/provider/provider.component.html
+++ b/angular-apollo-tailwind/src/app/provider/provider.component.html
@@ -8,4 +8,13 @@
       </form>
     </div>
   </div>
+
+  <div class="netlify-badge-container">
+    <a target="_blank" href="https://www.netlify.com">
+      <img
+        src="https://www.netlify.com/v3/img/components/netlify-light.svg"
+        alt="Deploys by Netlify"
+      />
+    </a>
+  </div>
 </div>

--- a/angular-apollo-tailwind/src/styles.css
+++ b/angular-apollo-tailwind/src/styles.css
@@ -1,3 +1,8 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+html,
+body {
+  height: 100%;
+}


### PR DESCRIPTION
This adds the Netlify badge (bottom of the page) to the Angular Apollo Tailwind showcase. It appears on all pages of the app (including the login screen)

![Screen Shot 2022-11-29 at 9 43 42 AM](https://user-images.githubusercontent.com/104345646/204618249-d7d75454-9b82-43f8-bfcd-55cbeb3a81d1.png)

![Screen Shot 2022-11-29 at 10 43 07 AM](https://user-images.githubusercontent.com/104345646/204618266-8175a7e5-074e-4875-aaa5-45f6b9ec7245.png)


This does not close the ticket #961 but checks one of its task.