### PR TITLE
feat(solidjs-tailwind): Adds RepoHeading Component

### DIFF
--- a/solidjs-tailwind/src/components/RepoHeading/PrivacyIcon.jsx
+++ b/solidjs-tailwind/src/components/RepoHeading/PrivacyIcon.jsx
@@ -1,0 +1,21 @@
+import { Show } from 'solid-js';
+import { LockClosedIcon } from 'solid-heroicons/outline';
+import { GitRepoIcon } from '../Icons/repo.icon';
+import styles from './RepoHeading.module.css';
+
+function PrivacyIcon(props) {
+  return (
+    <Show
+      when={typeof props.isPrivate !== 'undefined'}
+      fallback={<div class={styles.iconPlaceholder} />}
+    >
+      {props.isPrivate ? (
+        <LockClosedIcon class={styles.icon} />
+      ) : (
+        <GitRepoIcon class={styles.icon} />
+      )}
+    </Show>
+  );
+}
+
+export default PrivacyIcon;

--- a/solidjs-tailwind/src/components/RepoHeading/RepoHeading.jsx
+++ b/solidjs-tailwind/src/components/RepoHeading/RepoHeading.jsx
@@ -1,0 +1,34 @@
+import { Link } from '@solidjs/router';
+import PrivacyIcon from './PrivacyIcon';
+import { PrivacyBadge } from '../PrivacyBadge';
+import styles from './RepoHeading.module.css';
+
+function RepoHeading(props) {
+  return (
+    <h1 class={styles.heading}>
+      <PrivacyIcon isPrivate={props.data?.isPrivate} />
+      <span class={styles.navContainer}>
+        <Link
+          href={props.data?.isOrg ? `/orgs/${props.owner}` : `/${props.owner}`}
+        >
+          <a data-testid="header owner name" class={styles.ownerLink}>
+            {props.owner}
+          </a>
+        </Link>
+        <span class={styles.separator}>/</span>
+        <Link href={`/${props.owner}/${name}`}>
+          <a data-testid="header repo name" class={styles.nameLink}>
+            {name}
+          </a>
+        </Link>
+      </span>
+      {props.data ? (
+        <PrivacyBadge isPrivate={props.data.isPrivate} />
+      ) : (
+        <div class={styles.badgePlaceholder} />
+      )}
+    </h1>
+  );
+}
+
+export default RepoHeading;

--- a/solidjs-tailwind/src/components/RepoHeading/RepoHeading.module.css
+++ b/solidjs-tailwind/src/components/RepoHeading/RepoHeading.module.css
@@ -1,0 +1,33 @@
+@tailwind utilities;
+
+.heading {
+  @apply space-x-2.5 flex items-center text-xl;
+}
+
+.navContainer {
+  @apply space-x-1.5 mb-0.5;
+}
+
+.ownerLink {
+  @apply text-blue-600 hover:underline;
+}
+
+.nameLink {
+  @apply text-blue-600 font-semibold hover:underline;
+}
+
+.separator {
+  @apply text-gray-600;
+}
+
+.privacyIcon {
+  @apply w-6 h-6 text-gray-600;
+}
+
+.iconPlaceholder {
+  @apply w-6 h-6 bg-gray-200 opacity-25 rounded-lg;
+}
+
+.badgePlaceholder {
+  @apply w-8 h-6 bg-gray-200 opacity-25 rounded-xl;
+}

--- a/solidjs-tailwind/src/components/RepoHeading/RepoHeading.stories.jsx
+++ b/solidjs-tailwind/src/components/RepoHeading/RepoHeading.stories.jsx
@@ -1,14 +1,6 @@
 import RepoHeading from './RepoHeading';
 
-export default {
-  component: RepoHeading,
-  title: 'RepoPage/RepoHeading',
-};
-
-const Template = (args) => <RepoHeading {...args} />;
-
-export const Public = Template.bind({});
-Public.args = {
+const args = {
   name: 'starter.dev',
   owner: 'thisdot',
   data: {
@@ -23,26 +15,27 @@ Public.args = {
   },
 };
 
+export default {
+  component: RepoHeading,
+  title: 'RepoPage/RepoHeading',
+};
+
+const Template = (args) => <RepoHeading {...args} />;
+
+export const Public = Template.bind({});
+Public.args = args;
+
 export const Private = Template.bind({});
 Private.args = {
-  name: 'starter.dev',
-  owner: 'thisdot',
+  ...args,
   data: {
+    ...args.data,
     isPrivate: true,
-    stargazerCount: 30,
-    forkCount: 10,
-    watcherCount: 5,
-    openIssueCount: 2,
-    openPullRequestCount: 1,
-    topics: [],
-    isOrg: true,
   },
 };
 
 export const Loading = Template.bind({});
 Loading.args = {
-  name: 'starter.dev',
-  owner: 'thisdot',
-  isRepoLoading: true,
+  ...args,
   data: undefined,
 };

--- a/solidjs-tailwind/src/components/RepoHeading/RepoHeading.stories.tsx
+++ b/solidjs-tailwind/src/components/RepoHeading/RepoHeading.stories.tsx
@@ -1,0 +1,48 @@
+import RepoHeading from './RepoHeading';
+
+export default {
+  component: RepoHeading,
+  title: 'RepoPage/RepoHeading',
+};
+
+const Template = (args) => <RepoHeading {...args} />;
+
+export const Public = Template.bind({});
+Public.args = {
+  name: 'starter.dev',
+  owner: 'thisdot',
+  data: {
+    isPrivate: false,
+    stargazerCount: 30,
+    forkCount: 10,
+    watcherCount: 5,
+    openIssueCount: 2,
+    openPullRequestCount: 1,
+    topics: [],
+    isOrg: true,
+  },
+};
+
+export const Private = Template.bind({});
+Private.args = {
+  name: 'starter.dev',
+  owner: 'thisdot',
+  data: {
+    isPrivate: true,
+    stargazerCount: 30,
+    forkCount: 10,
+    watcherCount: 5,
+    openIssueCount: 2,
+    openPullRequestCount: 1,
+    topics: [],
+    isOrg: true,
+  },
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  name: 'starter.dev',
+  owner: 'thisdot',
+  isRepoLoading: true,
+  data: undefined,
+};

--- a/solidjs-tailwind/src/components/RepoHeading/index.ts
+++ b/solidjs-tailwind/src/components/RepoHeading/index.ts
@@ -1,0 +1,1 @@
+export { default as RepoHeading } from './RepoHeading';


### PR DESCRIPTION
This PR ports over the RepoHeading component for use in the solid showcase

### Changes
- Adds RepoHeading component
- Adds PrivacyIcon component
- Adds RepoHeading css module
- Adds RepoHeading story

Closes #935 