### PR TITLE
[sveltekit-pod] IssueSearchAssignees.svelte: Remove !important from SCSS

### DIFF
--- a/svelte-kit-scss/src/lib/components/IssueSearch/IssueSearchListItem/IssueSearchAssignees.svelte
+++ b/svelte-kit-scss/src/lib/components/IssueSearch/IssueSearchListItem/IssueSearchAssignees.svelte
@@ -21,7 +21,7 @@
     {#each assigneesReversed as assignee, i}
       <div
         class="assignee"
-        style="margin-right: {computeMarginRightPx(i)}px;"
+        style={`--squish-margin: ${computeMarginRightPx(i)}px`}
         class:last={i === assigneesCount - 1}
       >
         <img class="image" src={assignee.avatarUrl} alt={assignee.login} />
@@ -42,9 +42,9 @@
       height: 100%;
       &:hover {
         .assignee {
-          margin-right: 4px !important;
+          margin-right: 4px;
           &.last {
-            margin-right: 0px !important;
+            margin-right: 0px;
           }
         }
       }
@@ -53,6 +53,7 @@
         width: $size;
         display: inline-block;
         transition: margin-right 0.3s ease-in-out;
+        margin-right: var(--squish-margin, 0px);
         .image {
           border-radius: 100%;
           height: 100%;


### PR DESCRIPTION
Resolves: #967

> File: svelte-kit-scss/src/lib/components/IssueSearch/IssueSearchListItem/IssueSearchAssignees.svelte
> - look into removing the `!important` from the `margin-right` property
> `!important` is almost never the right solution. It has overreaching implications of overriding user styles and limits the ability to override styles in the future. Since this is a showcase app, showing our expertise is important, and I don't think `!important` in the CSS reflects well on us.