### PR TITLE
[sveltekit-pod] RepositoryCard.spec.ts: Uncomment the skipped test

### DIFF
--- a/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.spec.ts
+++ b/svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import RepositoryCard from './RepositoryCard.svelte';
 import { topRepositoriesFixture } from '$lib/fixtures';
+import { relativeTimeFmt } from '../../helpers';
 
 describe('RepositoryCard', () => {
   beforeEach(() => {
@@ -35,8 +36,8 @@ describe('RepositoryCard', () => {
     expect(license).toBeTruthy();
   });
 
-  // it('should should render repo last update', () => {
-  //   const lastUpdate = screen.getByText(/weeks ago/);
-  //   expect(lastUpdate).toBeTruthy();
-  // });
+  it('should should render repo last update', () => {
+    const lastUpdate = screen.getByText(relativeTimeFmt('2022-10-25T16:41:51Z'));
+    expect(lastUpdate).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Resolves: #972

> File: svelte-kit-scss/src/lib/components/RepositoryCard/RepositoryCard.spec.ts
> In order to expidite merging we commented out a failing test.
> - line 38: `it('should should render repo last update', () => {` test is commented out
> Please uncomment and fix, or remove test if it is not appropriate