### PR TITLE
[sveltekit-pod] Dropdown: Add aria-attributes to our custom multiselect dropdown

### DIFF
--- a/svelte-kit-scss/src/lib/components/shared/Dropdown/DropdownMenuSelect/DropdownMenuSelect.svelte
+++ b/svelte-kit-scss/src/lib/components/shared/Dropdown/DropdownMenuSelect/DropdownMenuSelect.svelte
@@ -19,14 +19,21 @@
 
 <DropdownMenu {description}>
   <slot />
-  <div slot="content">
+  <div slot="content" role="listbox">
     {#each options as option}
       <DropdownMenuItemLayout
         on:click={() => handleOptionClick(option)}
         on:keypress={() => handleOptionClick(option)}
       >
         {#if $$slots.option}
-          <slot name="option" {option} {checkedPredicate} {labelAccessor} />
+          <slot
+            aria-selected
+            role="option"
+            name="option"
+            {option}
+            {checkedPredicate}
+            {labelAccessor}
+          />
         {:else}
           <DropdownItemTemplateCheckbox
             label={labelAccessor(option)}

--- a/svelte-kit-scss/src/lib/components/shared/Dropdown/item-templates/DropdownItemTemplateCheckbox.svelte
+++ b/svelte-kit-scss/src/lib/components/shared/Dropdown/item-templates/DropdownItemTemplateCheckbox.svelte
@@ -9,7 +9,7 @@
   <div class="check-mark">
     <Check16 class="icon" />
   </div>
-  <div class="label">
+  <div class="label" aria-label={label}>
     {label}
   </div>
 </div>


### PR DESCRIPTION
Resolves: #969

> File: svelte-kit-scss/src/lib/components/shared/Dropdown/item-templates/DropdownItemTemplateCheckbox.svelte
>    + related files if required
> - I think we need to add some aria listbox attributes to this custom multi select dropdown
> - https://www.w3.org/TR/wai-aria-1.1/#listbox
> This will demonstrate our commitment to accessibility and show that we are aware of it in our showcases.
> 