### PR TITLE
add missing path import to server

### DIFF
--- a/starter-dev-backend/src/server.js
+++ b/starter-dev-backend/src/server.js
@@ -3,6 +3,7 @@ import serverless from 'serverless-http';
 import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import path from 'path';
 import {
   accessToken,
   clearCookies,


### PR DESCRIPTION
Per debugging this error:
![image](https://user-images.githubusercontent.com/1815379/206752988-c9f543af-469a-41d2-8009-53b9e9f58f98.png)

We got these logs:
![Screenshot 2022-12-09 at 10 59 03 AM](https://user-images.githubusercontent.com/1815379/206752970-2ea56485-c1ef-4ebc-8a9b-858d787f2aa5.png)


which indicate we needed to actually import "path" in node 16. 