### PR TITLE
[sveltekit-pod] Fix Readme markdown preview. Build markdown moved to server side

### DIFF
--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
@@ -1,25 +1,10 @@
 <script lang="ts">
   import { ListUnordered16 } from 'svelte-octicons';
-  import MarkdownIt from 'markdown-it';
-  import sanitizeHtml from 'sanitize-html';
-  import { Buffer } from 'buffer';
 
-  export let readme: string;
-  const md = new MarkdownIt();
-
-  function encodeReadmeURI(text: string) {
-    const encoded = text;
-    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-    return sanitizeHtml(md.render(decoded), {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'details', 'summary']),
-      allowedAttributes: {
-        img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
-      },
-    });
-  }
+  export let html: string;
 </script>
 
-{#if readme}
+{#if html}
   <div id="readme">
     <div class="header">
       <span class="icon">
@@ -29,7 +14,7 @@
     </div>
     <div class="content">
       <span>
-        {@html encodeReadmeURI(readme)}
+        {@html html}
       </span>
     </div>
   </div>

--- a/svelte-kit-scss/src/lib/helpers/repository-contents.ts
+++ b/svelte-kit-scss/src/lib/helpers/repository-contents.ts
@@ -1,6 +1,8 @@
 import type { FileExplorerFolderContentItem } from '$lib/components/FileExplorer/models';
 import { GithubRepoContentsItemType } from '$lib/constants/github';
-import type { GithubRepoContentsItem } from '$lib/interfaces';
+import type { GithubFileContentsItem, GithubRepoContentsItem } from '$lib/interfaces';
+import MarkdownIt from 'markdown-it';
+import sanitizeHtml from 'sanitize-html';
 
 export const composeDirHref = (
   path: string,
@@ -38,3 +40,35 @@ export const remapFileExplorerFolderContentsItem = (
       ? composeDirHref(item.path, username, repo, branch, defaultBranch)
       : composeFileHref(item.path, username, repo, branch),
 });
+
+export const MARKDOWN_ALLOWED_ENCODING: BufferEncoding[] = [
+  'ascii',
+  'utf8',
+  'utf-8',
+  'utf16le',
+  'ucs2',
+  'ucs-2',
+  'base64',
+  'base64url',
+  'latin1',
+  'binary',
+  'hex',
+];
+
+/** **Use only on server side!** */
+export const buildMarkdownPreviewHtml = (file: GithubFileContentsItem): string => {
+  const { content, encoding } = file;
+  const md = new MarkdownIt();
+  const bufferEncoding = MARKDOWN_ALLOWED_ENCODING.find((x) => x === encoding);
+  if (!bufferEncoding) {
+    console.warn(`Unsupported encoding: ${bufferEncoding}`);
+    return content;
+  }
+  const decoded = Buffer.from(content, bufferEncoding).toString('utf8');
+  return sanitizeHtml(md.render(decoded), {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'details', 'summary']),
+    allowedAttributes: {
+      img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
+    },
+  });
+};

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/(file-view)/[...tree]/+page.server.ts
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/(file-view)/[...tree]/+page.server.ts
@@ -1,5 +1,6 @@
 import { ENV } from '$lib/constants/env';
 import {
+  buildMarkdownPreviewHtml,
   composeDirHref,
   remapBranchOption,
   remapFileExplorerFolderContentsItem,
@@ -65,7 +66,7 @@ export const load: PageServerLoad = async ({ params, parent, fetch }) => {
     ...layoutData,
     parentHref,
     contents,
-    readme: readmeData.content,
+    readmeHtml: buildMarkdownPreviewHtml(readmeData),
     branches: branches.map((branch) =>
       remapBranchOption(branch, (branchName: string) =>
         composeDirHref(folderPath, username, repo, branchName, repositoryState.defaultBranch)

--- a/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/(file-view)/[...tree]/+page.svelte
+++ b/svelte-kit-scss/src/routes/(authenticated)/[username]/[repo]/(file-view)/[...tree]/+page.svelte
@@ -2,11 +2,19 @@
   import FileExplorerAbout from '$lib/components/FileExplorer/FileExplorerAbout/FileExplorerAbout.svelte';
   import FileExplorerContainer from '$lib/components/FileExplorer/FileExplorerContainer/FileExplorerContainer.svelte';
   import FileExplorerNav from '$lib/components/FileExplorer/FileExplorerNav/FileExplorerNav.svelte';
-  // import FileExplorerReadme from '$lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte';
+  import FileExplorerReadme from '$lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte';
   import type { PageServerData } from './$types';
   export let data: PageServerData;
 
-  $: ({ parentHref, contents, branches, defaultBranch, currentBranch, repositoryState } = data);
+  $: ({
+    parentHref,
+    contents,
+    branches,
+    defaultBranch,
+    currentBranch,
+    repositoryState,
+    readmeHtml,
+  } = data);
 </script>
 
 <div class="container grid grid-cols-12 subpage">
@@ -19,9 +27,9 @@
     <FileExplorerAbout {repositoryState} />
   </section>
 
-  <!-- <section class="col-span-9">
-    <FileExplorerReadme readme={data?.readme} />
-  </section> -->
+  <section class="col-span-9">
+    <FileExplorerReadme html={readmeHtml} />
+  </section>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
resolves #1058 

Result: 
![image](https://user-images.githubusercontent.com/31627738/207583372-3f0f5f2c-62c4-4ed3-8b48-4a75b78a7026.png)
