### PR TITLE
fix(svelte-kit-scss): replace api url in example.env and remove alias…

### DIFF
--- a/svelte-kit-scss/.env.example
+++ b/svelte-kit-scss/.env.example
@@ -1,3 +1,3 @@
-VITE_API_URL=https://api.starter.dev
+VITE_API_URL=https://api.starter.dev/.netlify/functions/server
 VITE_CLIENT_REDIRECT_URL=http://127.0.0.1:5173/signin/redirect
 VITE_GITHUB_URL=https://api.github.com

--- a/svelte-kit-scss/vite.config.ts
+++ b/svelte-kit-scss/vite.config.ts
@@ -1,7 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
 import { configDefaults, type UserConfig as VitestConfig } from 'vitest/config';
-import path from 'path';
 
 const config: UserConfig & { test: VitestConfig['test'] } = {
   plugins: [sveltekit()],
@@ -27,12 +26,6 @@ const config: UserConfig & { test: VitestConfig['test'] } = {
     },
     // Exclude playwright tests folder
     exclude: [...configDefaults.exclude, 'tests'],
-  },
-
-  resolve: {
-    alias: {
-      $lib: path.resolve(__dirname, './src/lib'),
-    },
   },
 };
 


### PR DESCRIPTION
The PR updates the `env.example` file with the new API endpoint and removes an unnecessary alias that SvelteKit was warning about:
 
<img width="473" alt="Screenshot 2022-12-14 at 1 07 41 PM" src="https://user-images.githubusercontent.com/76821/207693120-a07aae0f-b57b-45cc-9ad9-fdc8b8fe78c4.png">
