### PR TITLE
feat(qwik): Clicking in top repo card is not being redirected

### DIFF
--- a/qwik-graphql-tailwind/src/components/repo-card/repo-card.tsx
+++ b/qwik-graphql-tailwind/src/components/repo-card/repo-card.tsx
@@ -1,4 +1,5 @@
 import { component$ } from '@builder.io/qwik';
+import { Link } from '@builder.io/qwik-city';
 import { Repo, TopRepo } from '~/utils/types';
 import { PrivacyBadge } from '../privacy-badge/privacy-badge';
 import { RepoMeta } from '../repo-meta/repo-meta';
@@ -21,9 +22,9 @@ export const RepoCard = component$(({ repo, styles }: RepoCardProps) => {
   return (
     <div key={id} className={styles.item}>
       <h3 className="mb-2">
-        <a href={`/${owner}/${name}`} className={styles.headingLink}>
+        <Link href={`/${owner}/${name}`} className={styles.headingLink}>
           {name}
-        </a>
+        </Link>
         <PrivacyBadge isPrivate={isPrivate} className="relative bottom-0.5" />
       </h3>
       <div className={styles.description}>{description}</div>


### PR DESCRIPTION
## Description

- [x] When the user clicks on a Top Repo is not being redirected to the detail of that repo, but if he clicks on the same repo on the user profile is being redirected.

Closes: #1098 