### PR TITLE
[svelte-kit-scss] Fix: BoxLayout component overflow(:hidden) issue for header/footer (filters aren't usable)

### DIFF
--- a/svelte-kit-scss/src/lib/components/shared/layouts/BoxLayout.svelte
+++ b/svelte-kit-scss/src/lib/components/shared/layouts/BoxLayout.svelte
@@ -34,7 +34,6 @@
     .border-area {
       border: $border;
       border-radius: 6px;
-      overflow: hidden;
       background-color: variables.$white;
       .header,
       .footer {


### PR DESCRIPTION
resolves #1102 