### PR TITLE
[svelte-kit-scss] P2: Fix Execution Time For Search On Profile Page

### DIFF
--- a/svelte-kit-scss/src/lib/components/RepositoryList/RepositoryListFilters/SearchInputDelayed.svelte
+++ b/svelte-kit-scss/src/lib/components/RepositoryList/RepositoryListFilters/SearchInputDelayed.svelte
@@ -3,7 +3,7 @@
   import { Search16, Sync16 } from 'svelte-octicons';
 
   export let value: string | null | undefined;
-  export let delay = 1000;
+  export let delay = 2000;
   let timeout: NodeJS.Timeout | undefined = undefined;
   $: loading = Boolean(timeout);
 

--- a/svelte-kit-scss/src/lib/components/RepositoryList/RepositoryListFilters/SearchInputDelayed.svelte
+++ b/svelte-kit-scss/src/lib/components/RepositoryList/RepositoryListFilters/SearchInputDelayed.svelte
@@ -3,7 +3,7 @@
   import { Search16, Sync16 } from 'svelte-octicons';
 
   export let value: string | null | undefined;
-  export let delay = 3000;
+  export let delay = 1000;
   let timeout: NodeJS.Timeout | undefined = undefined;
   $: loading = Boolean(timeout);
 


### PR DESCRIPTION
Resolves: #1090

P2: search on profile page takes too long to execute. debounce should be much lower - probably ~300ms
