### PR TITLE
feat(solidjs-pod): fix order on File Explorer

### DIFF
--- a/solidjs-tailwind/src/components/FileExplorer/FileExplorer.jsx
+++ b/solidjs-tailwind/src/components/FileExplorer/FileExplorer.jsx
@@ -1,13 +1,10 @@
-import { For } from 'solid-js';
-import { Link } from '@solidjs/router';
+import { createResource, createSignal, createEffect, For } from 'solid-js';
+import { Link, useParams } from '@solidjs/router';
 import { DocumentIcon, FolderIcon } from '../Icons';
 import styles from './FileExplorer.module.css';
 import { useRepo } from '../../contexts/RepoContext';
-import { useParams } from '@solidjs/router';
-import { createResource } from 'solid-js';
 import getRepoTree from '../../services/get-repo-tree';
-import { createSignal } from 'solid-js';
-import { createEffect } from 'solid-js';
+import { parseQueryData } from './parseTree';
 
 const FileExplorerView = () => {
   const [tree, setTree] = createSignal([]);
@@ -28,7 +25,7 @@ const FileExplorerView = () => {
 
   createEffect(() => {
     if (resTree() && !resTree.loading) {
-      setTree(resTree()?.tree);
+      setTree(parseQueryData(resTree()?.tree));
     }
   });
 

--- a/solidjs-tailwind/src/components/FileExplorer/parseTree.js
+++ b/solidjs-tailwind/src/components/FileExplorer/parseTree.js
@@ -1,0 +1,19 @@
+export function parseQueryData(fileTree) {
+  const items =
+    fileTree?.map(({ name, path, type }) => {
+      return {
+        name,
+        path: path ?? '',
+        type,
+      };
+    }) ?? [];
+  return items.sort((a, b) => {
+    if (a.type === 'tree' && b.type !== 'tree') {
+      return -1;
+    }
+    if (a.type !== 'tree' && b.type === 'tree') {
+      return 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}


### PR DESCRIPTION
## Description

- [x] The files and folders are currently not listed in the correct order when viewing repo contents. Directories should be first, and individual files should be listed next.

Closes: #1181 

## Screenshot

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/14813235/211018590-11dcddbf-c777-43f2-adc4-2f79352e5ee6.png">


