### PR TITLE
nested folder nav fixed

### DIFF
--- a/qwik-graphql-tailwind/src/components/file-explorer/index.tsx
+++ b/qwik-graphql-tailwind/src/components/file-explorer/index.tsx
@@ -40,12 +40,17 @@ export const FileExplorer = component$(({ tree }: { tree: any[] }) => {
                   <DocumentIcon className="w-5 h-5 text-gray-500" />
                 )}
               </div>
-              <Link href={`${basePath}/${item.type}/${globalStore.branch || pathBranch}/${item.path}`}>
+              <a href={`${basePath}/${item.type}/${globalStore.branch || pathBranch}/${item.path}`}>
                 <span class="hover:text-blue-600 hover:underline">{item.name}</span>
-              </Link>
+              </a>
             </div>
           </div>
         ))}
+        {!tree.length ? (
+          <div class="animate-pulse">
+            <div class="w-full h-10 border-b border-gray-300 last-of-type:border-none bg-gray-200" />
+          </div>
+        ) : null}
       </div>
     </>
   );


### PR DESCRIPTION
# Description
- Issue happens when you navigate into nested folder directories (see screenshot below). Unable to see contents of the clicked folder and back arrow navigation does not function properly. Manually refreshing the page does fix the issue. When clicking a file to view its contents, the URL updates, but the page doesn't update. This is why refreshing the page works because it then forces the current URL in the address bar to load.

![Image](https://user-images.githubusercontent.com/1828602/211392140-7f16a847-fcc7-426d-b073-7df21d94bebb.png)

