### PR TITLE
[svelte-kit-scss] HTML in README isn't parsing as code block

### DIFF
--- a/svelte-kit-scss/src/lib/helpers/repository-contents.ts
+++ b/svelte-kit-scss/src/lib/helpers/repository-contents.ts
@@ -67,9 +67,10 @@ export const buildMarkdownPreviewHtml = (file: GithubFileContentsItem): string =
   }
   const decoded = Buffer.from(content, bufferEncoding).toString('utf8');
   return sanitizeHtml(md.render(decoded), {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'details', 'summary']),
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'details', 'summary', 'a']),
     allowedAttributes: {
       img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
+      a: ['href'],
     },
   });
 };

--- a/svelte-kit-scss/src/lib/helpers/repository-contents.ts
+++ b/svelte-kit-scss/src/lib/helpers/repository-contents.ts
@@ -59,7 +59,7 @@ export const MARKDOWN_ALLOWED_ENCODING: BufferEncoding[] = [
 /** **Use only on server side!** */
 export const buildMarkdownPreviewHtml = (file: GithubFileContentsItem): string => {
   const { content, encoding } = file;
-  const md = new MarkdownIt();
+  const md = new MarkdownIt({ html: true });
   const bufferEncoding = MARKDOWN_ALLOWED_ENCODING.find((x) => x === encoding);
   if (!bufferEncoding) {
     console.warn(`Unsupported encoding: ${bufferEncoding}`);


### PR DESCRIPTION
Closes #1198 