### PR TITLE
[svelte-kit-scss] Style README row width to match files row

### DIFF
--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
@@ -31,8 +31,8 @@
     font-weight: 600;
     padding: 0.625rem;
     border: 1px solid variables.$gray300;
-    border-top-right-radius: .25em;
-    border-top-left-radius: .25em;
+    border-top-right-radius: 0.25em;
+    border-top-left-radius: 0.25em;
 
     .icon {
       margin-right: 0.5rem;

--- a/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
+++ b/svelte-kit-scss/src/lib/components/FileExplorer/FileExplorerReadme/FileExplorerReadme.svelte
@@ -31,7 +31,8 @@
     font-weight: 600;
     padding: 0.625rem;
     border: 1px solid variables.$gray300;
-    border-radius: 0.25rem;
+    border-top-right-radius: .25em;
+    border-top-left-radius: .25em;
 
     .icon {
       margin-right: 0.5rem;
@@ -41,7 +42,8 @@
   .content {
     padding: 0.625rem;
     border: 1px solid variables.$gray300;
-    border-radius: 0.25rem;
+    border-bottom-left-radius: 0.25em;
+    border-bottom-right-radius: 0.25em;
     border-top: none;
   }
 </style>


### PR DESCRIPTION
Fixes #1187

- [ ] the README row is wider than the other file rows (see image)
- [x] Also, rounded corners between the heading and the contents of the README.

![image](https://user-images.githubusercontent.com/9017620/211599493-24533674-ae53-46ea-8977-df5942c5e7e3.png)

<hr/>

Couldn't replicate the differing width on my system, tested on Opera and Chrome

This PR fixes the border issue