### PR TITLE
[svelte-kit-scss] Storybook should use the main stylesheet as the app

### DIFF
--- a/svelte-kit-scss/.storybook/preview.js
+++ b/svelte-kit-scss/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '/src/routes/styles.scss';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {


### PR DESCRIPTION
Resolves: #1287

> 
> # Description
> - Storybook global styles should be the same as application global styles(routes/styles.scss)
> 
> ![Image](https://user-images.githubusercontent.com/1828602/213208283-c19c367a-b1a5-4371-8cec-b7569cbba074.png)
> 
