### PR TITLE
Solidjs: filter option works as expected

### DIFF
--- a/solidjs-tailwind/src/components/PRAndIssuesHeader/PRAndIssuesHeader.jsx
+++ b/solidjs-tailwind/src/components/PRAndIssuesHeader/PRAndIssuesHeader.jsx
@@ -18,9 +18,9 @@ const PRAndIssuesHeader = (props) => {
   } = usePrAndIssuesContext();
 
   const sortOptions = Object.values(SORT_OPTIONS);
-  const selectSort = (value) =>  setSortBy(value);
+  const selectSort = (value) =>  setSortBy(sortBy() === value ? 'Newest' : value);
   const labelOptions = createMemo(() => Object.values({...labelOpt().map((label) => label.name)}))
-  const selectLabel = (value) =>  setSelectedLabel(value)
+  const selectLabel = (value) => setSelectedLabel(selectedLabel() !== value ? value : undefined);
 
   return (
     <div class="flex flex-wrap space-x-1 space-y-2 md:space-x-0 md:space-y-0 items-center justify-between p-4 bg-gray-100 border-b rounded-t-lg">


### PR DESCRIPTION
# Description
- filters should be able to be reset, should be able to click on a selected filter and deselect it after it's been selected, or have the option to Select all.
- when clicking the "X" none of the filters or filtered results are cleared. It doesn't appear to be doing anything currently.



![Image](https://user-images.githubusercontent.com/1828602/213084370-4ea117da-0d43-4e4b-b1f1-f0b9ad1106c2.png)

## Result

How it works is when you click on a filter option twice it resets to the default, for example; for sort option the default is newest while for label option the default on nothing..