### PR TITLE
[Next] Fix: Add Netlify badge to sign in screen

### DIFF
--- a/next-react-query-tailwind/src/components/NavBar/NavBar.tsx
+++ b/next-react-query-tailwind/src/components/NavBar/NavBar.tsx
@@ -9,22 +9,22 @@ function NavBar() {
   const user = session?.user;
   return (
     <header className={styles.header}>
-      <Link href="/">
-        <a>
-          <GitHubLogo />
-        </a>
-      </Link>
-      <div>
-        <div>
-          {user ? (
-            <UserDropdown image={user.image} />
-          ) : (
-            <Link href="/api/auth/signin">
-              <a className={styles.navLink}>Sign In</a>
-            </Link>
-          )}
-        </div>
-      </div>
+      {user ? (
+        <>
+          <Link href="/">
+            <a>
+              <GitHubLogo />
+            </a>
+          </Link>
+          <div>
+            <div>
+              <UserDropdown image={user.image} />
+            </div>
+          </div>
+        </>
+      ) : (
+        ''
+      )}
     </header>
   );
 }

--- a/next-react-query-tailwind/src/components/UserDropdown/UserDropdown.view.tsx
+++ b/next-react-query-tailwind/src/components/UserDropdown/UserDropdown.view.tsx
@@ -16,7 +16,7 @@ function UserDropdownView({ image, username }: UserDropdownViewProps) {
   const { replace } = useRouter();
 
   const handleSignOut = () => {
-    signOut();
+    signOut({ callbackUrl: '/' });
     replace('/api/auth/signin');
   };
 

--- a/next-react-query-tailwind/src/components/UserDropdown/UserDropdown.view.tsx
+++ b/next-react-query-tailwind/src/components/UserDropdown/UserDropdown.view.tsx
@@ -16,7 +16,7 @@ function UserDropdownView({ image, username }: UserDropdownViewProps) {
   const { replace } = useRouter();
 
   const handleSignOut = () => {
-    signOut({ redirect: false });
+    signOut();
     replace('/api/auth/signin');
   };
 
@@ -25,7 +25,13 @@ function UserDropdownView({ image, username }: UserDropdownViewProps) {
       <Menu.Button role="button" className={styles.dropdownBtn}>
         <div className={styles.avatarContainer}>
           {image && (
-            <Image data-testid="user avatar header" src={image} alt="Profile Photo" width={32} height={32} />
+            <Image
+              data-testid="user avatar header"
+              src={image}
+              alt="Profile Photo"
+              width={32}
+              height={32}
+            />
           )}
         </div>
         <ChevronDownIcon className="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />

--- a/next-react-query-tailwind/src/lib/withAuthRedirect.ts
+++ b/next-react-query-tailwind/src/lib/withAuthRedirect.ts
@@ -14,7 +14,7 @@ export function withAuthRedirect(
       return {
         redirect: {
           permanent: false,
-          destination: '/api/auth/signin',
+          destination: '/auth/signin',
         },
       };
     }

--- a/next-react-query-tailwind/src/pages/api/auth/[...nextauth].ts
+++ b/next-react-query-tailwind/src/pages/api/auth/[...nextauth].ts
@@ -40,6 +40,14 @@ const options: NextAuthOptions = {
       session.error = token.error;
       return session;
     },
+    async signIn(user) {
+      const isAllowedToSignIn = user ? true : false;
+      if (isAllowedToSignIn) {
+        return true;
+      } else {
+        return false;
+      }
+    },
   },
   providers: [
     Providers.GitHub({
@@ -48,6 +56,9 @@ const options: NextAuthOptions = {
       scope: ['user', 'read:org'],
     }),
   ],
+  pages: {
+    signIn: '/auth/signin',
+  },
 };
 
 const handler = (req: NextApiRequest, res: NextApiResponse) =>

--- a/next-react-query-tailwind/src/pages/auth/signin.tsx
+++ b/next-react-query-tailwind/src/pages/auth/signin.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @next/next/no-img-element */
+import { CtxOrReq, getProviders, signIn } from 'next-auth/client';
+import { InferGetServerSidePropsType } from 'next';
+
+export default function SignIn({
+  providers,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      {providers
+        ? Object.values(providers).map((provider) => (
+            <div key={provider.name}>
+              <button onClick={() => signIn(provider.id, { callbackUrl: '/' })}>
+                Sign in with {provider.name}
+              </button>
+            </div>
+          ))
+        : ''}
+
+      <div className="flex justify-center mt-auto pb-5 pt-6">
+        <a
+          target="_blank"
+          rel="noreferrer noopener"
+          href="https://www.netlify.com"
+        >
+          <img
+            src="https://www.netlify.com/v3/img/components/netlify-light.svg"
+            alt="Deploys by Netlify"
+          />
+        </a>
+      </div>
+    </>
+  );
+}
+
+export async function getServerSideProps(context: CtxOrReq) {
+  const providers = await getProviders();
+  return {
+    props: { providers },
+  };
+}

--- a/next-react-query-tailwind/src/pages/auth/signin.tsx
+++ b/next-react-query-tailwind/src/pages/auth/signin.tsx
@@ -22,7 +22,7 @@ export default function SignIn({
                 </button>
               </div>
             ))
-          : ''}
+          : null}
 
         <div className="w-11/12 pb-6">
           <a

--- a/next-react-query-tailwind/src/pages/auth/signin.tsx
+++ b/next-react-query-tailwind/src/pages/auth/signin.tsx
@@ -7,28 +7,37 @@ export default function SignIn({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
-      {providers
-        ? Object.values(providers).map((provider) => (
-            <div key={provider.name}>
-              <button onClick={() => signIn(provider.id, { callbackUrl: '/' })}>
-                Sign in with {provider.name}
-              </button>
-            </div>
-          ))
-        : ''}
+      <section className="flex flex-col items-center w-full h-full bg-gray-900">
+        {providers
+          ? Object.values(providers).map((provider) => (
+              <div
+                key={provider.name}
+                className="flex justify-center content-center h-5/6 w-11/12"
+              >
+                <button
+                  className="self-center w-3/5 lg:w-1/5 py-5 px-2 text-white border-solid border-white border-2   rounded-sm hover:text-gray-900 hover:bg-white transition-colors"
+                  onClick={() => signIn(provider.id, { callbackUrl: '/' })}
+                >
+                  Sign in with {provider.name}
+                </button>
+              </div>
+            ))
+          : ''}
 
-      <div className="flex justify-center mt-auto pb-5 pt-6">
-        <a
-          target="_blank"
-          rel="noreferrer noopener"
-          href="https://www.netlify.com"
-        >
-          <img
-            src="https://www.netlify.com/v3/img/components/netlify-light.svg"
-            alt="Deploys by Netlify"
-          />
-        </a>
-      </div>
+        <div className="w-11/12 pb-6">
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
+            href="https://www.netlify.com"
+          >
+            <img
+              src="https://www.netlify.com/v3/img/components/netlify-light.svg"
+              alt="Deploys by Netlify"
+              className="m-auto"
+            />
+          </a>
+        </div>
+      </section>
     </>
   );
 }

--- a/next-react-query-tailwind/src/pages/index.tsx
+++ b/next-react-query-tailwind/src/pages/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import type { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import { withAuthRedirect } from '@lib/withAuthRedirect';
@@ -29,7 +30,11 @@ const Home: NextPage = () => {
         </main>
       </div>
       <div className="flex justify-center mt-auto pb-5 pt-6">
-        <a target="_blank" rel="noreferrer noopener" href="https://www.netlify.com">
+        <a
+          target="_blank"
+          rel="noreferrer noopener"
+          href="https://www.netlify.com"
+        >
           <img
             src="https://www.netlify.com/v3/img/components/netlify-light.svg"
             alt="Deploys by Netlify"


### PR DESCRIPTION
Initially, we were using the default sign in screen that Next Auth provided for us, and with that we didn't have a way of adding the Netlify badge on that screen. So this PR handles creating a custom sign in screen that Next Auth can use, that we can add the badge onto.

Since I needed to create a new page, I also had to make a few adjustments so that things redirected as a user would expect, and also hid the nav bar on the sign in page so it's not confusing. Becuase the nav bar wouldn't hide completely, I made the background of the sign in page the same dark blue color to match it. 

I've tested everything locally and it all appears to be working - users can sign in and navigate as expected.

Side note: the es-lint ignore rule is because Next wants us to use their `Image` component instead of the HTML `img` element, but doing so requires us to add a width & height or display property to the badge, which didn't seem right to me since this is directly what Netlify asks us to use.

Screenshots of the new page (the little red icon in the bottom left is the React Query devtools icon, and doesn't show on production):
<img width="1634" alt="Screen Shot 2023-01-19 at 3 44 54 PM" src="https://user-images.githubusercontent.com/16214572/213571341-d062532b-00c6-4e6c-8c03-4243d7032cc6.png">


<img width="492" alt="Screen Shot 2023-01-19 at 3 48 11 PM" src="https://user-images.githubusercontent.com/16214572/213571358-7d68b199-1410-41b6-a885-ae8b05757d7a.png">
