### PR TITLE
solid-fix: header tab in repo page 

### DIFF
--- a/solidjs-tailwind/src/components/PRAndIssuesData/PRAndIssuesData.jsx
+++ b/solidjs-tailwind/src/components/PRAndIssuesData/PRAndIssuesData.jsx
@@ -5,21 +5,19 @@ import { PRAndIssuesHeader } from "../PRAndIssuesHeader";
 export const PRAndIssuesData = (props) => {
   return (
     <div class="border border-gray-300 rounded-lg">
-      {props.data.length > 0 ? (
-        <div>
-          <PRAndIssuesHeader {...props}/>
+      <PRAndIssuesHeader {...props}/>
+        {props.data.length > 0 ? (
           <For each={props.data}>
             {(data) => <PRAndIssuesListItem {...data()} />}
           </For>
-        </div>
-      ) : (
-        <div class="text-center p-3 flex flex-col items-center justify-center">
-          <span class="font-bold mb-4">No results matched your search.</span>
-          <a class=" text-blue-600 underline" href={location.pathname}>
-            Refresh
-          </a>
-        </div>
-      )}
+        ) : (
+          <div class="text-center p-3 flex flex-col items-center justify-center">
+            <span class="font-bold mb-4">No results matched your search.</span>
+            <a class=" text-blue-600 underline" href={location.pathname}>
+              Refresh
+            </a>
+          </div>
+        )}
     </div>
   );
 }

--- a/solidjs-tailwind/src/components/TabNavigation/TabNavigation.jsx
+++ b/solidjs-tailwind/src/components/TabNavigation/TabNavigation.jsx
@@ -4,10 +4,10 @@ import cn from 'classnames';
 import styles from './TabNavigation.module.css';
 
 const TabNavigation = (props) => {
-  const isCurrentTab = (href) => {
-    return props.pathname === href ? true  : false;
+  const isCurrentTab = (pathName) => {
+    const otherPaths = props.tabs.filter(({ path }) => path !== pathName).map(({ path }) => path);
+    return pathName !== '' ? props.pathname.includes(pathName) : otherPaths.every((path) => !props.pathname.includes(path));
   };
-
 
   return (
     <div class={`${styles.container} ${props.class}`}>
@@ -23,7 +23,7 @@ const TabNavigation = (props) => {
                 href={href}
                 key={index}
                 class={`${
-                  isCurrentTab(href)
+                  isCurrentTab(item.path)
                     ? styles.tabActive
                     : styles.tabInactive
                 } ${styles.tab}`}


### PR DESCRIPTION
Fixed header tab highlight in repo page and fixed no result behaviour in issues and prs page (now the header is visible also when we have no results and filter could be deselected)

Fixes: #1313 