### PR TITLE
[Angular-NgRx] Fix: API call being made too early

### DIFF
--- a/angular-ngrx-scss/src/app/home/home.component.ts
+++ b/angular-ngrx-scss/src/app/home/home.component.ts
@@ -17,7 +17,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.user$.pipe(takeUntil(this.destroy$)).subscribe((user) => {
-      this.store.dispatch(fetchUserData({ username: user }));
+      if (user !== '') {
+        this.store.dispatch(fetchUserData({ username: user }));
+      }
     });
   }
 


### PR DESCRIPTION
Closes #1295 

The showcase was triggering an API call before it had the user's username, hence why the call was failing. Added a check so that the API call only sends once there's a username to send with it.