### PR TITLE
solid-fix: manage loading status on every pages

### DIFF
--- a/solidjs-tailwind/src/components/BranchNavigation/BranchNavigation.jsx
+++ b/solidjs-tailwind/src/components/BranchNavigation/BranchNavigation.jsx
@@ -1,13 +1,13 @@
 import { For } from 'solid-js';
-import { Link } from '@solidjs/router';
+import { useNavigate, useParams } from '@solidjs/router';
 import { GitBranchIcon } from '../Icons';
 import styles from './BranchNavigation.module.css';
-import { useParams } from '@solidjs/router';
 import { useRepo } from '../../contexts/RepoContext';
 
 function BranchNavigation() {
   const params = useParams();
   const { info } = useRepo();
+  const navigate = useNavigate();
 
   const branch = info().branch || params.branch;
 
@@ -28,14 +28,14 @@ function BranchNavigation() {
       </button>
       {params.path?.split('/').filter(Boolean).length > 0 && (
         <div class={styles.crumbs}>
-          <Link href={`/${params.owner}/${params.name}`}>
+          <div onClick={() => navigate(`/${params.owner}/${params.name}`)}>
             <a
               data-testid={`file explorer nav root ${params.name}`}
               class={styles.rootLink}
             >
               {params.name}
             </a>
-          </Link>
+          </div>
           <span class={styles.separator}>/</span>
           <For each={params.path?.split('/').filter(Boolean)}>
             {(crumb, index) => (
@@ -50,14 +50,14 @@ function BranchNavigation() {
                   </span>
                 ) : (
                   <>
-                    <Link href={`${hrefPath(index())}`}>
+                    <div onClick={() => navigate(`${hrefPath(index())}`)}>
                       <a
                         data-testid={`file explorer nav crumb ${crumb}`}
                         class={styles.crumbLink}
                       >
                         {crumb}
                       </a>
-                    </Link>
+                    </div>
                     <span class={styles.separator}>/</span>
                   </>
                 )}

--- a/solidjs-tailwind/src/components/FileExplorer/FileExplorer.jsx
+++ b/solidjs-tailwind/src/components/FileExplorer/FileExplorer.jsx
@@ -1,5 +1,5 @@
 import { createResource, createSignal, createEffect, For } from 'solid-js';
-import { Link, useParams } from '@solidjs/router';
+import { useParams, useNavigate } from '@solidjs/router';
 import { DocumentIcon, FolderIcon } from '../Icons';
 import styles from './FileExplorer.module.css';
 import { useRepo } from '../../contexts/RepoContext';
@@ -9,18 +9,21 @@ import { parseQueryData } from './parseTree';
 const FileExplorerView = () => {
   const { info } = useRepo();
   const params = useParams();
+  const navigate = useNavigate();
   const [tree, setTree] = createSignal([]);
 
   const branch = params.branch || info().branch;
   const basePath = `/${params.owner}/${params.name}`;
   const backLink = `${basePath}/tree/${branch}/${params.path}`;
 
-  const [resTree] = createResource(() => `${branch}_${params.path}`, () =>
-    getRepoTree({
-      owner: params.owner,
-      name: params.name,
-      expression: `${branch}:${params.path || ''}`,
-    })
+  const [resTree] = createResource(
+    () => `${branch}_${params.path}`,
+    () =>
+      getRepoTree({
+        owner: params.owner,
+        name: params.name,
+        expression: `${branch}:${params.path || ''}`,
+      })
   );
 
   createEffect(() => {
@@ -36,11 +39,11 @@ const FileExplorerView = () => {
       ) : (
         <div class={styles.container}>
           {params.path && (
-            <Link href={backLink}>
+            <div onClick={() => navigate(backLink)}>
               <a class={styles.cellBack}>
                 <div class="text-blue-600">..</div>
               </a>
-            </Link>
+            </div>
           )}
           <For each={tree()}>
             {(item) => (
@@ -53,8 +56,12 @@ const FileExplorerView = () => {
                       <DocumentIcon class={styles.iconFile} />
                     )}
                   </div>
-                  <Link
-                    href={`${basePath}/${item.type}/${branch}/${item.path}`}
+                  <div
+                    onClick={() =>
+                      navigate(
+                        `${basePath}/${item.type}/${branch}/${item.path}`
+                      )
+                    }
                   >
                     <a
                       data-testid={`file explorer list ${item.name}`}
@@ -62,7 +69,7 @@ const FileExplorerView = () => {
                     >
                       {item.name}
                     </a>
-                  </Link>
+                  </div>
                 </div>
               </div>
             )}

--- a/solidjs-tailwind/src/components/RepoFilter/FilterText.jsx
+++ b/solidjs-tailwind/src/components/RepoFilter/FilterText.jsx
@@ -1,4 +1,3 @@
-import { useLocation } from '@solidjs/router';
 import { Show, splitProps } from 'solid-js';
 import { CloseIcon } from '../Icons';
 import { defaultFilterType, defaultLanguage } from './data';
@@ -17,8 +16,12 @@ const modifyFilterTypeText = (filterText = 'test') => {
 };
 
 const FilterText = (props) => {
-  const [local] = splitProps(props, ['filteredRepoCount']);
-  const location = useLocation();
+  const [local] = splitProps(props, ['filteredRepoCount', 'setFilterType', 'setLanguage']);
+
+  const clearFilters = () => {
+    local.setFilterType(defaultFilterType);
+    local.setLanguage(defaultLanguage)
+  }
 
   return (
     <div class={styles.filterTextContainer}>
@@ -47,8 +50,8 @@ const FilterText = (props) => {
           </span>
         </small>
       </div>
-      <div>
-        <a href={location.pathname} class={styles.clearFilter}>
+      <div onClick={() => clearFilters()}>
+        <a class={styles.clearFilter}>
           <span class={styles.closeIconSpan}>
             <CloseIcon />
           </span>

--- a/solidjs-tailwind/src/components/RepoFilter/RepoFilter.jsx
+++ b/solidjs-tailwind/src/components/RepoFilter/RepoFilter.jsx
@@ -82,7 +82,11 @@ const RepoFilter = (props) => {
         </div>
       </div>
       <Show when={!isOnlySorted()}>
-        <FilterText filteredRepoCount={merged.filteredRepoCount} />
+        <FilterText 
+          filteredRepoCount={merged.filteredRepoCount} 
+          setFilterType={setFilterType} 
+          setLanguage={setLanguage}
+        />
       </Show>
     </>
   );

--- a/solidjs-tailwind/src/components/RepoFilter/RepoFilter.module.css
+++ b/solidjs-tailwind/src/components/RepoFilter/RepoFilter.module.css
@@ -49,7 +49,7 @@
 }
 
 .clearFilter {
-  @apply flex items-center hover:text-blue-600 transition-colors delay-[60ms] no-underline gap-2 text-sm;
+  @apply flex items-center hover:text-blue-600 transition-colors delay-[60ms] no-underline gap-2 text-sm cursor-pointer;
 }
 
 .closeIconSpan {

--- a/solidjs-tailwind/src/contexts/RepoContext.jsx
+++ b/solidjs-tailwind/src/contexts/RepoContext.jsx
@@ -61,7 +61,8 @@ export function RepoProvider(props) {
   });
 
   const repo = {
-    info, readme, setLoading
+    info,
+    readme,
   };
 
   return (

--- a/solidjs-tailwind/src/pages/RepoBlob.jsx
+++ b/solidjs-tailwind/src/pages/RepoBlob.jsx
@@ -1,23 +1,20 @@
-import { RepoProvider } from '../contexts/RepoContext';
 import { BranchNavigation } from '../components/BranchNavigation';
 import { FileViewer } from '../components/FileViewer';
 import { RepoHeader } from '../components/RepoHeader/';
 
 const RepoBlob = () => {
   return (
-    <RepoProvider>
-      <div class="bg-white h-screen">
-        <RepoHeader />
-        <div class="max-w-screen-2xl mx-auto md:py-8 px-4">
-          <div class="grid grid-cols-12 gap-8">
-            <div class="col-span-12 md:col-span-7 xl:col-span-9">
-              <BranchNavigation />
-              <FileViewer />
-            </div>
+    <div class="bg-white h-screen">
+      <RepoHeader />
+      <div class="max-w-screen-2xl mx-auto md:py-8 px-4">
+        <div class="grid grid-cols-12 gap-8">
+          <div class="col-span-12 md:col-span-7 xl:col-span-9">
+            <BranchNavigation />
+            <FileViewer />
           </div>
         </div>
       </div>
-    </RepoProvider>
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixed loading status on every page.

Now when we navigate through repo folders and file, only the page's content is loaded and the header remains visible.

Also, in Profile page, when we set and clear filters only the list of repos is loaded and not the whole page.

Fixes: #1320 