### PR TITLE
changed the review port to 3000 in vite config

### DIFF
--- a/solidjs-tailwind/vite.config.js
+++ b/solidjs-tailwind/vite.config.js
@@ -4,6 +4,9 @@ import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
   plugins: [spaFallbackWithDot(), solidPlugin()],
+  preview: {
+    port: 3000,
+  },
   server: {
     port: 3000,
     hmr: {


### PR DESCRIPTION
# Description
- there is an issue when running `yarn serve`. It goes to port 4173 but then when you authenticate or try to sign in it goes to port 3000. The redirect path is probably wrong and needs to be updated


## Solution
- configured preview port in vite config to port 3000
Then run this command. You have to run yarn build before you run yarn serve
```bash 
yarn build && yarn serve
```
