### PR TITLE
Solidjs-fix: label filter

### DIFF
--- a/solidjs-tailwind/src/services/get-issues.js
+++ b/solidjs-tailwind/src/services/get-issues.js
@@ -26,12 +26,12 @@ function parseIssues(connection) {
       (labels, label) =>
         label
           ? [
-            ...labels,
-            {
-              color: label.color,
-              name: label.name,
-            },
-          ]
+              ...labels,
+              {
+                color: label.color,
+                name: label.name,
+              },
+            ]
           : labels,
       []
     );
@@ -131,7 +131,7 @@ const getIssues = async ({
   const closedIssues = parseIssues(repository?.closedIssues);
   const openIssues = parseIssues(repository?.openIssues);
   const milestones = parseMilestones(repository?.milestones);
-  const labels = parseLabels(repository?.labels)
+  const labels = parseLabels(repository?.labels);
 
   return {
     openIssues,

--- a/solidjs-tailwind/src/services/get-issues.js
+++ b/solidjs-tailwind/src/services/get-issues.js
@@ -26,12 +26,12 @@ function parseIssues(connection) {
       (labels, label) =>
         label
           ? [
-              ...labels,
-              {
-                color: label.color,
-                name: label.name,
-              },
-            ]
+            ...labels,
+            {
+              color: label.color,
+              name: label.name,
+            },
+          ]
           : labels,
       []
     );
@@ -78,6 +78,23 @@ function parseMilestones(milestones) {
   }, []);
 }
 
+function parseLabels(labels) {
+  const nodes = labels?.nodes || [];
+  return nodes.reduce((labels, label) => {
+    if (!label) {
+      return labels;
+    }
+
+    return [
+      ...labels,
+      {
+        color: label.color,
+        name: label.name,
+      },
+    ];
+  }, []);
+}
+
 const getIssues = async ({
   owner,
   name,
@@ -114,26 +131,13 @@ const getIssues = async ({
   const closedIssues = parseIssues(repository?.closedIssues);
   const openIssues = parseIssues(repository?.openIssues);
   const milestones = parseMilestones(repository?.milestones);
-
-  const labelMap = [...closedIssues.issues, ...openIssues.issues].reduce(
-    (acc, issue) => {
-      const map = {};
-      issue.labels.forEach((label) => {
-        map[label.name] = label;
-      });
-      return {
-        ...acc,
-        ...map,
-      };
-    },
-    {}
-  );
+  const labels = parseLabels(repository?.labels)
 
   return {
     openIssues,
     closedIssues,
     milestones,
-    labels: Object.values(labelMap),
+    labels,
   };
 };
 

--- a/solidjs-tailwind/src/services/get-repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/get-repo-pull-requests.js
@@ -26,12 +26,12 @@ function parsePullRequests(connection) {
       (labels, label) =>
         label
           ? [
-              ...labels,
-              {
-                color: label.color,
-                name: label.name,
-              },
-            ]
+            ...labels,
+            {
+              color: label.color,
+              name: label.name,
+            },
+          ]
           : labels,
       []
     );
@@ -58,6 +58,23 @@ function parsePullRequests(connection) {
   }, []);
 
   return { pullRequests, totalCount, pageInfo };
+}
+
+function parseLabels(labels) {
+  const nodes = labels?.nodes || [];
+  return nodes.reduce((labels, label) => {
+    if (!label) {
+      return labels;
+    }
+
+    return [
+      ...labels,
+      {
+        color: label.color,
+        name: label.name,
+      },
+    ];
+  }, []);
 }
 
 /**
@@ -113,24 +130,12 @@ const getRepoPullRequests = async ({
     resp.data.repository?.closedPullRequest
   );
 
-  const labelMap = [
-    ...closedPullRequests.pullRequests,
-    ...openPullRequests.pullRequests,
-  ].reduce((acc, issue) => {
-    const map = {};
-    issue.labels.forEach((label) => {
-      map[label.name] = label;
-    });
-    return {
-      ...acc,
-      ...map,
-    };
-  }, {});
+  const labelMap = parseLabels(resp.data.repository?.labels)
 
   return {
     openPullRequests,
     closedPullRequests,
-    labels: Object.values(labelMap),
+    labels: labelMap
   };
 };
 

--- a/solidjs-tailwind/src/services/get-repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/get-repo-pull-requests.js
@@ -26,12 +26,12 @@ function parsePullRequests(connection) {
       (labels, label) =>
         label
           ? [
-            ...labels,
-            {
-              color: label.color,
-              name: label.name,
-            },
-          ]
+              ...labels,
+              {
+                color: label.color,
+                name: label.name,
+              },
+            ]
           : labels,
       []
     );
@@ -130,12 +130,12 @@ const getRepoPullRequests = async ({
     resp.data.repository?.closedPullRequest
   );
 
-  const labelMap = parseLabels(resp.data.repository?.labels)
+  const labelMap = parseLabels(resp.data.repository?.labels);
 
   return {
     openPullRequests,
     closedPullRequests,
-    labels: labelMap
+    labels: labelMap,
   };
 };
 

--- a/solidjs-tailwind/src/services/queries/issue-info.js
+++ b/solidjs-tailwind/src/services/queries/issue-info.js
@@ -17,6 +17,13 @@ export const ISSUES_QUERY = `
         }
         totalCount
       }
+      labels(first: 100) {
+        totalCount
+        nodes {
+          color
+          name
+        }
+      }
       openIssues: issues(
         first: $first
         last: $last

--- a/solidjs-tailwind/src/services/queries/repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/queries/repo-pull-requests.js
@@ -1,6 +1,13 @@
 export const REPO_PULL_REQUESTS = `
   query PullRequests($owner: String!, $name: String!, $first: Int, $last: Int, $before: String, $after: String, $labels: [String!], $orderBy: IssueOrderField!, $direction: OrderDirection!) {
     repository(owner: $owner, name: $name) {
+      labels(first: 100) {
+        totalCount
+        nodes {
+          color
+          name
+        }
+      }
       openPullRequest: pullRequests(first: $first, last: $last, states: [OPEN], after: $after, before: $before, labels: $labels, orderBy:{ field: $orderBy, direction: $direction}) {
         totalCount
         pageInfo {


### PR DESCRIPTION
Now Label Filter on the Prs page and on the issues page is always populated with all the Prs or issues' labels. Also if we select one filter, the dropdown always shows all the options.

Fixes: #1341 