### PR TITLE
Solidstart/get organization repos api

### DIFF
--- a/solidstart-tanstackquery-tailwind-modules/src/services/get-org-repos.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/get-org-repos.ts
@@ -1,0 +1,33 @@
+import FetchApi from './api';
+import { useAuth } from '../auth';
+import { GITHUB_GRAPHQL } from '../utils/constants';
+import { ORGANIZATION_REPOS_QUERY } from './queries/org-repos';
+import { OrgRepoInfo } from '~/types/org-repos';
+
+type Variables = Record<string, string | number | null> | null;
+type Response = {
+  data: OrgRepoInfo;
+};
+
+const getOrgRepos = async (variables: Variables) => {
+  const { authStore } = useAuth();
+
+  const data = {
+    url: `${GITHUB_GRAPHQL}`,
+    query: ORGANIZATION_REPOS_QUERY,
+    variables,
+    headersOptions: {
+      authorization: `Bearer ${authStore.token}`,
+    },
+  };
+  const resp = (await FetchApi(data)) as Response;
+  return {
+    orgInfo: {
+      avatarUrl: resp.data?.organization?.avatarUrl,
+      name: resp.data?.organization?.name,
+    },
+    repositories: resp?.data?.organization?.repositories,
+  };
+};
+
+export default getOrgRepos;

--- a/solidstart-tanstackquery-tailwind-modules/src/services/queries/org-repos.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/queries/org-repos.ts
@@ -1,0 +1,29 @@
+export const ORGANIZATION_REPOS_QUERY = `
+  query OrganizationRepos($organization: String!, $first: Int!) {
+    organization(login: $organization) {
+      avatarUrl
+      name
+      repositories(first: $first) {
+        edges {
+          node {
+            name
+            description
+            url
+            forkCount
+            stargazerCount
+            primaryLanguage {
+              color
+              name
+              id
+            }
+            updatedAt
+            owner {
+              login
+            }
+            visibility
+          }
+        }
+      }
+    }
+  }
+`;

--- a/solidstart-tanstackquery-tailwind-modules/src/types/org-repos.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/types/org-repos.ts
@@ -1,0 +1,25 @@
+export interface Repository {
+    name: string;
+    description: string;
+    url: string;
+    forkCount: number;
+    stargazerCount: number;
+    primaryLanguage: {
+        color: string;
+        name: string;
+        id: string;
+    };
+    updatedAt: string;
+    owner: {
+        login: string;
+    };
+    visibility: string;
+}
+
+export interface OrgRepoInfo {
+    organization: {
+        avatarUrl: string;
+        name: string;
+        repositories: Repository[];
+    }
+}

--- a/solidstart-tanstackquery-tailwind-modules/src/types/org-repos.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/types/org-repos.ts
@@ -1,25 +1,25 @@
 export interface Repository {
+  name: string;
+  description: string;
+  url: string;
+  forkCount: number;
+  stargazerCount: number;
+  primaryLanguage: {
+    color: string;
     name: string;
-    description: string;
-    url: string;
-    forkCount: number;
-    stargazerCount: number;
-    primaryLanguage: {
-        color: string;
-        name: string;
-        id: string;
-    };
-    updatedAt: string;
-    owner: {
-        login: string;
-    };
-    visibility: string;
+    id: string;
+  };
+  updatedAt: string;
+  owner: {
+    login: string;
+  };
+  visibility: string;
 }
 
 export interface OrgRepoInfo {
-    organization: {
-        avatarUrl: string;
-        name: string;
-        repositories: Repository[];
-    }
+  organization: {
+    avatarUrl: string;
+    name: string;
+    repositories: Repository[];
+  };
 }


### PR DESCRIPTION
Closes: #1354 

# Get Organization repositories from GitHub API

## Background

There will be a view for an organization’s profile, which, similar to the user’s profile, will list all of the organization’s repositories.

## Acceptance

- [x] Get organization repositories from GitHub API
- [x] For display on organization page; data needed:
    - [x] Repo name
    - [x] description
    - [x] language
    - [x] star count
    - [x] fork count
    - [x] last updated
    - [x] visibility tag

## Notes

- This query should start sorted by most recently updated.
