### PR TITLE
Solidstart/User Profile API

### DIFF
--- a/solidstart-tanstackquery-tailwind-modules/src/services/get-user-profile.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/get-user-profile.ts
@@ -1,0 +1,30 @@
+import FetchApi, { ApiProps } from './api';
+import { useAuth } from '../auth';
+import { GITHUB_GRAPHQL } from '../utils/constants';
+import { USER_PROFILE_QUERY } from './queries/user-profile';
+import { UserProfile } from '~/types/user-profile-type';
+
+type Variables = Record<string, string | number | null> | null;
+type Response = {
+  data: {
+    user: UserProfile;
+  };
+};
+
+const userProfile = async (variables: Variables) => {
+  const { authStore } = useAuth();
+
+  const data: ApiProps = {
+    url: `${GITHUB_GRAPHQL}`,
+    query: USER_PROFILE_QUERY,
+    variables,
+    headersOptions: {
+      authorization: `Bearer ${authStore.token}`,
+    },
+  };
+  const resp = (await FetchApi(data)) as Response;
+
+  return resp.data?.user;
+};
+
+export default userProfile;

--- a/solidstart-tanstackquery-tailwind-modules/src/services/queries/user-profile.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/queries/user-profile.ts
@@ -1,0 +1,29 @@
+export const USER_PROFILE_QUERY = `
+  query UserProfile($username: String!) {
+    user(login: $username) {
+      avatarUrl
+      bio
+      company
+      followers(first: 0) {
+        totalCount
+      }
+      following(first: 0) {
+        totalCount
+      }
+      location
+      login
+      name
+      organizations(first: 6) {
+        nodes {
+          avatarUrl
+          login
+        }
+      }
+      starredRepositories(first: 0) {
+        totalCount
+      }
+      twitterUsername
+      websiteUrl
+    }
+  }
+`;

--- a/solidstart-tanstackquery-tailwind-modules/src/types/user-profile-type.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/types/user-profile-type.ts
@@ -1,25 +1,25 @@
 export interface UserProfile {
-    avatarUrl: string;
-    bio: string;
-    company: string;
-    followers: {
-        totalCount: number;
-    };
-    following: {
-        totalCount: number;
-    };
-    location: string;
-    login: string;
-    name: string;
-    organizations: {
-        nodes: {
-            avatarUrl: string;
-            login: string;
-        }[];
-    };
-    starredRepositories: {
-        totalCount: number;
-    };
-    twitterUsername: string;
-    websiteUrl: string;
+  avatarUrl: string;
+  bio: string;
+  company: string;
+  followers: {
+    totalCount: number;
+  };
+  following: {
+    totalCount: number;
+  };
+  location: string;
+  login: string;
+  name: string;
+  organizations: {
+    nodes: {
+      avatarUrl: string;
+      login: string;
+    }[];
+  };
+  starredRepositories: {
+    totalCount: number;
+  };
+  twitterUsername: string;
+  websiteUrl: string;
 }

--- a/solidstart-tanstackquery-tailwind-modules/src/types/user-profile-type.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/types/user-profile-type.ts
@@ -1,0 +1,25 @@
+export interface UserProfile {
+    avatarUrl: string;
+    bio: string;
+    company: string;
+    followers: {
+        totalCount: number;
+    };
+    following: {
+        totalCount: number;
+    };
+    location: string;
+    login: string;
+    name: string;
+    organizations: {
+        nodes: {
+            avatarUrl: string;
+            login: string;
+        }[];
+    };
+    starredRepositories: {
+        totalCount: number;
+    };
+    twitterUsername: string;
+    websiteUrl: string;
+}


### PR DESCRIPTION
Closes: #1352

# Get Profile information from GitHub API

## Background

For the profile page, we want to fairly closely resemble the GitHub user page. This section is focused on the user “card”, where you can see profile information about the user.

## Acceptance

- [x] Get user info from GitHub API
- [x] For display on profile page; data needed:
    - [x] Photo
    - [x] Name (display name)
    - [x] username (login name)
    - [x] description
    - [x] followers
    - [x] following
    - [x] stars
    - [x] company info
    - [x] location info
    - [x] blog link
    - [x] organizations (need name and avatar)

## Notes


