### PR TITLE
Issues information API

### DIFF
--- a/solidstart-tanstackquery-tailwind-modules/src/services/get-issues.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/get-issues.ts
@@ -1,0 +1,143 @@
+import FetchApi from './api';
+import { useAuth } from '../auth';
+import { ISSUES_QUERY } from './queries/issue-info';
+import { GITHUB_GRAPHQL } from '../utils/constants';
+import { LabelProps, MilestoneProps, Variables, Response, IssueProps, Issue } from '~/types/issues-type';
+
+function parseIssues(data: IssueProps) {
+  if (!data) {
+    return {
+      issues: [],
+      totalCount: 0,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    };
+  }
+
+  const pageInfo = data.pageInfo;
+  const nodes = data.nodes || [];
+  const totalCount = data.totalCount;
+
+  const issues = nodes.reduce((issues: Issue[], issue) => {
+    if (!issue) {
+      return issues;
+    }
+
+    const labelNodes: LabelProps[] = issue.labels?.nodes || [];
+    const labels = labelNodes.reduce(
+      (labels:LabelProps[], label) =>
+        label
+          ? [
+              ...labels,
+              {
+                color: label.color,
+                name: label.name,
+              },
+            ]
+          : labels,
+      []
+    );
+
+    return [
+      ...issues,
+      {
+        login: issue.author?.login,
+        commentCount: issue.comments.totalCount,
+        labelCount: issue.labels.totalCount,
+        labels,
+        title: issue.title,
+        number: issue.number,
+        createdAt: issue.createdAt,
+        closedAt: issue.closedAt,
+        state: issue.state,
+        url: issue.url,
+      },
+    ];
+  }, []);
+
+  return { issues, totalCount, pageInfo };
+}
+
+function parseMilestones(milestones: { nodes: MilestoneProps[] }) {
+  const nodes = milestones?.nodes || [];
+  return nodes.reduce((milestones: MilestoneProps[], milestone) => {
+    if (!milestone) {
+      return milestones;
+    }
+
+    return [
+      ...milestones,
+      {
+        id: milestone.id,
+        closed: milestone.closed,
+        title: milestone.title,
+        number: milestone.number,
+        description: milestone.description,
+      },
+    ];
+  }, []);
+}
+
+function parseLabels(labels: { nodes: LabelProps[] }) {
+  const nodes = labels?.nodes || [];
+  return nodes.reduce((labels: LabelProps[], label) => {
+    if (!label) {
+      return labels;
+    }
+
+    return [
+      ...labels,
+      {
+        color: label.color,
+        name: label.name,
+      },
+    ];
+  }, []);
+}
+
+const getIssues = async ({
+  owner,
+  name,
+  orderBy,
+  direction,
+  filterBy,
+  before,
+  after,
+  first,
+  last,
+}: Variables) => {
+  const { authStore } = useAuth();
+
+  const data = {
+    url: `${GITHUB_GRAPHQL}`,
+    query: ISSUES_QUERY,
+    variables: {
+      owner,
+      name,
+      first,
+      last,
+      orderBy,
+      direction,
+      filterBy,
+      before,
+      after,
+    },
+    headersOptions: {
+      authorization: `Bearer ${authStore.token}`,
+    },
+  };
+  const resp = (await FetchApi(data)) as Response;
+  const repository = resp.data?.repository;
+  const closedIssues = parseIssues(repository?.closedIssues);
+  const openIssues = parseIssues(repository?.openIssues);
+  const milestones = parseMilestones(repository?.milestones);
+  const labels = parseLabels(repository?.labels);
+
+  return {
+    openIssues,
+    closedIssues,
+    milestones,
+    labels,
+  };
+};
+
+export default getIssues;

--- a/solidstart-tanstackquery-tailwind-modules/src/services/get-issues.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/get-issues.ts
@@ -2,7 +2,14 @@ import FetchApi from './api';
 import { useAuth } from '../auth';
 import { ISSUES_QUERY } from './queries/issue-info';
 import { GITHUB_GRAPHQL } from '../utils/constants';
-import { LabelProps, MilestoneProps, Variables, Response, IssueProps, Issue } from '~/types/issues-type';
+import {
+  LabelProps,
+  MilestoneProps,
+  Variables,
+  Response,
+  IssueProps,
+  Issue,
+} from '~/types/issues-type';
 
 function parseIssues(data: IssueProps) {
   if (!data) {
@@ -24,7 +31,7 @@ function parseIssues(data: IssueProps) {
 
     const labelNodes: LabelProps[] = issue.labels?.nodes || [];
     const labels = labelNodes.reduce(
-      (labels:LabelProps[], label) =>
+      (labels: LabelProps[], label) =>
         label
           ? [
               ...labels,

--- a/solidstart-tanstackquery-tailwind-modules/src/services/queries/issue-info.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/services/queries/issue-info.ts
@@ -1,0 +1,106 @@
+export const ISSUES_QUERY = `
+  query IssuesQuery($owner: String!, $name: String!, $first: Int, $last: Int, $before: String, $after: String, $orderBy: IssueOrderField!, $direction: OrderDirection!, $filterBy: IssueFilters) {
+    repository(owner: $owner, name: $name) {
+      milestones(first: 100, states: [OPEN]) {
+        nodes {
+          id
+          closed
+          description
+          number
+          title
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        totalCount
+      }
+      labels(first: 100) {
+        totalCount
+        nodes {
+          color
+          name
+        }
+      }
+      openIssues: issues(
+        first: $first
+        last: $last
+        states: [OPEN]
+        after: $after
+        before: $before
+        filterBy: $filterBy
+        orderBy:{ field: $orderBy, direction: $direction}
+      ) {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+            state
+            createdAt
+            closedAt
+            labels(first: 100) {
+              totalCount
+              nodes {
+                color
+                name
+              }
+            }
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+          }
+      }
+
+      closedIssues: issues(
+        first: $first
+        last: $last
+        states: [CLOSED]
+        after: $after
+        before: $before
+        filterBy: $filterBy
+        orderBy:{ field: $orderBy, direction: $direction}
+      ) {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+            state
+            createdAt
+            closedAt
+            labels(first: 100) {
+              totalCount
+              nodes {
+                color
+                name
+              }
+            }
+            comments {
+              totalCount
+            }
+            number
+            author {
+              login
+            }
+            url
+            title
+          }
+      }
+    }
+  }
+`;

--- a/solidstart-tanstackquery-tailwind-modules/src/types/issues-type.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/types/issues-type.ts
@@ -1,0 +1,89 @@
+export interface MilestoneProps {
+  id: string;
+  closed: boolean;
+  description: string;
+  number: number;
+  title: string;
+}
+
+export interface LabelProps {
+  color: string;
+  name: string;
+}
+
+export interface PageInfo {
+  startCursor: string;
+  endCursor: string;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface IssueProps {
+  totalCount: number;
+  pageInfo: PageInfo;
+  nodes: IssueNodeProps[];
+}
+
+export interface IssueNodeProps {
+  state: string;
+  createdAt: string;
+  closedAt: string;
+  title: string;
+  author: {
+    login: string;
+  };
+  url: string;
+  labels: {
+    totalCount: number;
+    nodes: LabelProps[];
+  };
+  comments: {
+    totalCount: number;
+  };
+  number: number;
+}
+
+export interface IssuesInfo {
+  repository: {
+    milestones: {
+      nodes: MilestoneProps[];
+      pageInfo: PageInfo;
+      totalCount: number;
+    };
+    labels: {
+      totalCount: number;
+      nodes: LabelProps[];
+    };
+    openIssues: IssueProps;
+    closedIssues: IssueProps;
+  };
+}
+
+export interface Issue {
+  login: string;
+  commentCount: number;
+  labelCount: number;
+  labels: LabelProps[];
+  title: string;
+  number: number;
+  createdAt: string;
+  closedAt: string;
+  state: string;
+  url: string;
+}
+
+export type Variables = {
+  owner: string;
+  name: string;
+  orderBy: string;
+  direction: string;
+  filterBy: string;
+  before: string;
+  after: string;
+  first: string;
+  last: string;
+};
+
+export type Response = {
+  data: IssuesInfo;
+};


### PR DESCRIPTION
Closes: #1360

# Get issue information from GitHub API

## Background

On the single repo page, we’ll have a tab for viewing open and closed issues. We do not (currently) have the functionality to click into the issues, so this ticket will be for creating the initial view that mostly concerns the name of the issue and some metadata about each one.

## Acceptance

- [x] Get repository issues from GitHub API
- [x] For display in issues tab on single repository page; data needed:
    - [x] name of issue
    - [x] issue number
    - [x] name of person who created the issue
    - [x] created / closed date
    - [x] number of comments

## Notes

