### PR TITLE
Solidstart/create single repo view about section

### DIFF
--- a/solidstart-tanstackquery-tailwind-modules/package.json
+++ b/solidstart-tanstackquery-tailwind-modules/package.json
@@ -30,7 +30,6 @@
   "type": "module",
   "devDependencies": {
     "@babel/core": "^7.20.12",
-    "@storybook/addons": "^6.5.16",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-essentials": "6.5.16",
     "@storybook/addon-interactions": "6.5.16",

--- a/solidstart-tanstackquery-tailwind-modules/package.json
+++ b/solidstart-tanstackquery-tailwind-modules/package.json
@@ -30,6 +30,7 @@
   "type": "module",
   "devDependencies": {
     "@babel/core": "^7.20.12",
+    "@storybook/addons": "^6.5.16",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-essentials": "6.5.16",
     "@storybook/addon-interactions": "6.5.16",

--- a/solidstart-tanstackquery-tailwind-modules/src/components/Icons/BookOpenIcon.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/Icons/BookOpenIcon.tsx
@@ -1,0 +1,24 @@
+interface IconProps {
+  class: string;
+}
+
+const BookOpenIcon = (props: IconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      class={props.class ?? ''}
+      viewBox="0 0 24 24"
+      stroke-width={1.5}
+      stroke="currentColor"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-line-join="round"
+        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  );
+};
+
+export default BookOpenIcon;

--- a/solidstart-tanstackquery-tailwind-modules/src/components/Icons/LinkIcon.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/Icons/LinkIcon.tsx
@@ -1,0 +1,22 @@
+interface IconProps {
+  class: string;
+}
+
+const LinkIcon = (props: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class={props.class ?? ''}
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+    />
+  </svg>
+);
+
+export default LinkIcon;

--- a/solidstart-tanstackquery-tailwind-modules/src/components/Icons/index.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/Icons/index.ts
@@ -11,3 +11,5 @@ export { default as InformationCircleIcon } from './InformationCircleIcon';
 export { default as CodeIcon } from './CodeIcon';
 export { default as EyeIcon } from './EyeIcon';
 export { default as RepoIcon } from './RepoIcon';
+export { default as BookOpenIcon } from './BookOpenIcon';
+export { default as LinkIcon } from './LinkIcon';

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
@@ -4,7 +4,10 @@ interface DescriptionProps {
 
 export const Description = (props: DescriptionProps) => {
   return (
-    <span data-testid="repo file explorer description" class={props.text ? 'italic' : undefined}>
+    <span
+      data-testid="repo file explorer description"
+      class={props.text ? 'italic' : undefined}
+    >
       {props.text || 'No description, website, or topics provided.'}
     </span>
   );

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
@@ -1,0 +1,20 @@
+import { Match, Switch } from 'solid-js';
+
+interface DescriptionProps {
+  text: string;
+}
+
+export const Description = (props: DescriptionProps) => {
+  return (
+    <Switch>
+      <Match when={props.text}>
+        <span data-testid="repo file explorer description">{props.text}</span>
+      </Match>
+      <Match when={!props.text}>
+        <span class="italic" data-testid="repo file explorer description">
+          No description, website, or topics provided.
+        </span>
+      </Match>
+    </Switch>
+  );
+};

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Description.tsx
@@ -1,20 +1,11 @@
-import { Match, Switch } from 'solid-js';
-
 interface DescriptionProps {
-  text: string;
+  text?: string;
 }
 
 export const Description = (props: DescriptionProps) => {
   return (
-    <Switch>
-      <Match when={props.text}>
-        <span data-testid="repo file explorer description">{props.text}</span>
-      </Match>
-      <Match when={!props.text}>
-        <span class="italic" data-testid="repo file explorer description">
-          No description, website, or topics provided.
-        </span>
-      </Match>
-    </Switch>
+    <span data-testid="repo file explorer description" class={props.text ? 'italic' : undefined}>
+      {props.text || 'No description, website, or topics provided.'}
+    </span>
   );
 };

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
@@ -4,7 +4,7 @@ import { LinkIcon } from '../Icons';
 import styles from './RepoAbout.module.css';
 
 interface HomepageUrlProps {
-  homepageUrl: string;
+  homepageUrl?: string;
 }
 
 export const HomepageUrl = (props: HomepageUrlProps) => {
@@ -12,7 +12,7 @@ export const HomepageUrl = (props: HomepageUrlProps) => {
     <Show when={props.homepageUrl}>
       <div class={styles.linkContainer}>
         <LinkIcon class={styles.linkIcon} />
-        <A href={props.homepageUrl} class={styles.link} target="_blank">
+        <A href={props.homepageUrl ?? ""} class={styles.link} target="_blank">
           {props.homepageUrl}
         </A>
       </div>

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
@@ -1,0 +1,21 @@
+import { Show } from 'solid-js';
+import { A } from 'solid-start';
+import { LinkIcon } from '../Icons';
+import styles from './RepoAbout.module.css';
+
+interface HomepageUrlProps {
+  homepageUrl: string;
+}
+
+export const HomepageUrl = (props: HomepageUrlProps) => {
+  return (
+    <Show when={props.homepageUrl}>
+      <div class={styles.linkContainer}>
+        <LinkIcon class={styles.linkIcon} />
+        <A href={props.homepageUrl} class={styles.link} target="_blank">
+          {props.homepageUrl}
+        </A>
+      </div>
+    </Show>
+  );
+};

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
@@ -12,7 +12,7 @@ export const HomepageUrl = (props: HomepageUrlProps) => {
     <Show when={props.homepageUrl}>
       <div class={styles.linkContainer}>
         <LinkIcon class={styles.linkIcon} />
-        <A href={props.homepageUrl ?? ""} class={styles.link} target="_blank">
+        <A href={props.homepageUrl ?? ''} class={styles.link} target="_blank">
           {props.homepageUrl}
         </A>
       </div>

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/HomePageUrl.tsx
@@ -1,5 +1,5 @@
+import { A } from '@solidjs/router';
 import { Show } from 'solid-js';
-import { A } from 'solid-start';
 import { LinkIcon } from '../Icons';
 import styles from './RepoAbout.module.css';
 

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.module.css
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.module.css
@@ -1,0 +1,37 @@
+@tailwind utilities;
+
+.container {
+  @apply pb-8 space-y-5 border-b-2 border-gray-300;
+}
+
+.heading {
+  @apply text-gray-700 font-semibold;
+}
+
+.description {
+  @apply text-gray-600;
+}
+
+.readmeLink {
+  @apply flex items-center text-gray-500 hover:text-blue-500 text-sm cursor-pointer leading-snug;
+}
+
+.readmeIcon {
+  @apply h-5 w-5 mt-0.5 mr-2;
+}
+
+.linkContainer {
+  @apply max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap;
+}
+
+.linkIcon {
+  @apply w-4 h-4 inline text-gray-700 mr-2 -mt-0.5;
+}
+
+.link {
+  @apply font-semibold text-blue-600 hover:underline text-sm;
+}
+
+.topic {
+  @apply inline-block bg-blue-100 text-blue-600 text-xs font-medium py-1 px-2 rounded-xl mr-1.5 hover:text-white hover:bg-blue-600 transition-colors cursor-pointer;
+}

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
@@ -1,0 +1,29 @@
+import { Router } from '@solidjs/router';
+import { render } from 'solid-testing-library';
+import { describe, expect, it } from 'vitest';
+import 'whatwg-fetch';
+import { RepoAboutWidget } from './RepoAbout';
+
+describe('Repo About', () => {
+  it('should mount', async () => {
+    const wrapper = await render(() => (
+      <Router>
+        <RepoAboutWidget />
+      </Router>
+    ));
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('should show contents', async () => {
+    const wrapper = await render(() => (
+      <Router>
+        <RepoAboutWidget />
+      </Router>
+    ));
+
+    const contents = await wrapper.findByTestId('about-info');
+    const topic = await wrapper.findByText('A SolidJS starter template with TailwindCSS, TypeScript, and Jest');
+    expect(contents.innerHTML).toBeTruthy();
+    expect(topic).toBeVisible();
+  });
+});

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
@@ -22,7 +22,9 @@ describe('Repo About', () => {
     ));
 
     const contents = await wrapper.findByTestId('about-info');
-    const topic = await wrapper.findByText('A SolidJS starter template with TailwindCSS, TypeScript, and Jest');
+    const topic = await wrapper.findByText(
+      'A SolidJS starter template with TailwindCSS, TypeScript, and Jest'
+    );
     expect(contents.innerHTML).toBeTruthy();
     expect(topic).toBeVisible();
   });

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
@@ -22,9 +22,7 @@ describe('Repo About', () => {
     ));
 
     const contents = await wrapper.findByTestId('about-info');
-    const topic = await wrapper.findByText(
-      'This is a description'
-    );
+    const topic = await wrapper.findByText('This is a description');
     expect(contents.innerHTML).toBeTruthy();
     expect(topic).toBeVisible();
   });

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.spec.tsx
@@ -23,7 +23,7 @@ describe('Repo About', () => {
 
     const contents = await wrapper.findByTestId('about-info');
     const topic = await wrapper.findByText(
-      'A SolidJS starter template with TailwindCSS, TypeScript, and Jest'
+      'This is a description'
     );
     expect(contents.innerHTML).toBeTruthy();
     expect(topic).toBeVisible();

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.stories.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.stories.tsx
@@ -1,0 +1,14 @@
+import { Router } from '@solidjs/router';
+import { RepoAboutWidget } from './RepoAbout';
+
+export default {
+  title: 'Components/RepoAboutWidget',
+};
+
+const Template = () => (
+  <Router>
+    <RepoAboutWidget />
+  </Router>
+);
+
+export const Default = Template.bind({});

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.stories.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.stories.tsx
@@ -11,4 +11,4 @@ const Template = () => (
   </Router>
 );
 
-export const Default = Template.bind({});
+export const Default: any = Template.bind({});

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
@@ -1,0 +1,33 @@
+import { BookOpenIcon } from '../Icons';
+import { Description } from './Description';
+import { HomepageUrl } from './HomePageUrl';
+import { Topics } from './Topics';
+import styles from './RepoAbout.module.css';
+
+export const RepoAboutWidget = () => {
+  const info = {
+      description: 'A SolidJS starter template with TailwindCSS, TypeScript, and Jest',
+      homepageUrl: '',
+      topics: ['solidjs', 'tailwindcss', 'typescript', 'jest'],
+  }
+
+  return (
+    <div class={styles.container}>
+      <h3 class={styles.heading}>About</h3>
+      <div class={styles.description}>
+        <div data-testid="about-info" class="space-y-4">
+          <Description text={info?.description} />
+          <HomepageUrl homepageUrl={info?.homepageUrl} />
+          <Topics topics={info?.topics || []} />
+        </div>
+      </div>
+      <div>
+        <a class={styles.readmeLink}>
+          <BookOpenIcon class={styles.readmeIcon} /> Readme
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default RepoAboutWidget;

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
@@ -6,10 +6,11 @@ import styles from './RepoAbout.module.css';
 
 export const RepoAboutWidget = () => {
   const info = {
-      description: 'A SolidJS starter template with TailwindCSS, TypeScript, and Jest',
-      homepageUrl: '',
-      topics: ['solidjs', 'tailwindcss', 'typescript', 'jest'],
-  }
+    description:
+      'A SolidJS starter template with TailwindCSS, TypeScript, and Jest',
+    homepageUrl: '',
+    topics: ['solidjs', 'tailwindcss', 'typescript', 'jest'],
+  };
 
   return (
     <div class={styles.container}>

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
@@ -2,24 +2,19 @@ import { BookOpenIcon } from '../Icons';
 import { Description } from './Description';
 import { HomepageUrl } from './HomePageUrl';
 import { Topics } from './Topics';
+import { aboutData } from './data';
+
 import styles from './RepoAbout.module.css';
 
 export const RepoAboutWidget = () => {
-  const info = {
-    description:
-      'A SolidJS starter template with TailwindCSS, TypeScript, and Jest',
-    homepageUrl: '',
-    topics: ['solidjs', 'tailwindcss', 'typescript', 'jest'],
-  };
-
   return (
     <div class={styles.container}>
       <h3 class={styles.heading}>About</h3>
       <div class={styles.description}>
         <div data-testid="about-info" class="space-y-4">
-          <Description text={info?.description} />
-          <HomepageUrl homepageUrl={info?.homepageUrl} />
-          <Topics topics={info?.topics || []} />
+          <Description text={aboutData.info.data.description} />
+          <HomepageUrl homepageUrl={aboutData.info.data.homepageUrl} />
+          <Topics topics={aboutData.info.data.topics || []} />
         </div>
       </div>
       <div>

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/RepoAbout.tsx
@@ -18,9 +18,9 @@ export const RepoAboutWidget = () => {
         </div>
       </div>
       <div>
-        <a class={styles.readmeLink}>
+        <span class={styles.readmeLink}>
           <BookOpenIcon class={styles.readmeIcon} /> Readme
-        </a>
+        </span>
       </div>
     </div>
   );

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Topics.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Topics.tsx
@@ -1,0 +1,20 @@
+import { For } from 'solid-js';
+import styles from './RepoAbout.module.css';
+
+interface TopicsProps {
+  topics: string[];
+}
+
+export const Topics = (props: TopicsProps) => {
+  return (
+    <>
+      {props.topics.length === 0 ? null : (
+        <div class="space-y-1">
+          <For each={props.topics}>
+            {(topic) => <span class={styles.topic}>{topic}</span>}
+          </For>
+        </div>
+      )}
+    </>
+  );
+};

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Topics.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/Topics.tsx
@@ -1,4 +1,4 @@
-import { For } from 'solid-js';
+import { For, Show } from 'solid-js';
 import styles from './RepoAbout.module.css';
 
 interface TopicsProps {
@@ -7,14 +7,12 @@ interface TopicsProps {
 
 export const Topics = (props: TopicsProps) => {
   return (
-    <>
-      {props.topics.length === 0 ? null : (
-        <div class="space-y-1">
-          <For each={props.topics}>
-            {(topic) => <span class={styles.topic}>{topic}</span>}
-          </For>
-        </div>
-      )}
-    </>
+    <Show when={props.topics.length > 0}>
+      <div class="space-y-1">
+        <For each={props.topics}>
+          {(topic) => <span class={styles.topic}>{topic}</span>}
+        </For>
+      </div>
+    </Show>
   );
 };

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/data.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/data.ts
@@ -1,0 +1,9 @@
+export const aboutData = {
+  info: {
+    data: {
+      description: 'This is a description',
+      homepageUrl: 'https://www.google.com',
+      topics: ['topic1', 'topic2', 'topic3'],
+    },
+  },
+};

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/index.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoAbout/index.tsx
@@ -1,0 +1,1 @@
+export { default as RepoAbout } from './RepoAbout';

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoActionButtons/CountButtonGroup.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoActionButtons/CountButtonGroup.tsx
@@ -4,7 +4,7 @@ import styles from './RepoActionButtons.module.css';
 const formatCountString = (count: number) => {
   let countText = `${count}`;
   if (count && count > 1000) {
-    let digits = countText.split('');
+    const digits = countText.split('');
     digits.splice(digits.length - 3, 3);
     countText = `${digits.join('')}k`;
   }
@@ -19,7 +19,7 @@ type CountButtonGroupProps = {
 function CountButtonGroup(props: CountButtonGroupProps) {
   const merged = mergeProps({ count: 0 }, props);
   const c = children(() => props.children);
-  let buttonText = c()
+  const buttonText = c()
     ?.toString()
     .replace('[object Object],', '')
     .toLowerCase();


### PR DESCRIPTION
Close: #1389

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/36667083/217872648-c3e52ca1-9865-4c9c-ae2c-f5e1f059180d.png">

# Create single repo view about section

## Background

A sub-component of the single repo page, this component focuses on the about section. It should show the user details about the repository, and any links made available to the user from that section.

## Acceptance

- [x] About title
- [x] repo description
- [x] link icon and url for deployed version (if available)
- [x] open book icon and readme title
- [x] divider line

## Notes
