### PR TITLE
search functionality completed

### DIFF
--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/FilterText.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/FilterText.tsx
@@ -1,7 +1,13 @@
-import { Setter, Show, splitProps } from 'solid-js';
+import { Show, splitProps } from 'solid-js';
 import { CloseIcon } from '../Icons';
 import { defaultFilterType, defaultLanguage } from './data';
-import { filterType, language, search, sortBy } from './RepoFilter.store';
+import {
+  filterType,
+  language,
+  resetFilter,
+  search,
+  sortBy,
+} from './RepoFilter.store';
 import styles from './RepoFilter.module.css';
 
 const modifyFilterTypeText = (filterText = 'test') => {
@@ -17,18 +23,10 @@ const modifyFilterTypeText = (filterText = 'test') => {
 
 type FilterTextProps = {
   filteredRepoCount?: number;
-  setFilterType: Setter<string>;
-  setLanguage: Setter<string>;
 };
 
 const FilterText = (props: FilterTextProps) => {
-  const [local] = splitProps(props, [
-    'filteredRepoCount',
-    'setFilterType',
-    'setLanguage',
-  ]);
-
-  const clearFilters = () => 'clear';
+  const [local] = splitProps(props, ['filteredRepoCount']);
 
   return (
     <div class={styles.filterTextContainer}>
@@ -57,9 +55,17 @@ const FilterText = (props: FilterTextProps) => {
           </span>
         </small>
       </div>
-      <div onClick={() => clearFilters()}>
-        <a class={styles.clearFilter}>
-          <span class={styles.closeIconSpan}>
+      <div onClick={resetFilter}>
+        <a
+          class={
+            'flex items-center group hover:text-blue-600 transition-colors delay-[60ms] no-underline gap-2 text-sm cursor-pointer'
+          }
+        >
+          <span
+            class={
+              'text-white rounded-md bg-gray-500 group-hover:bg-blue-600 transition-colors delay-[60ms] w-4 h-4'
+            }
+          >
             <CloseIcon />
           </span>
           Clear filter

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.module.css
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.module.css
@@ -1,4 +1,5 @@
 @tailwind utilities;
+@tailwind base;
 
 .repoFilterContainer {
   @apply flex relative mb-4 space-x-4 border-b border-b-gray-300 pb-4;
@@ -46,14 +47,6 @@
 
 .filterText {
   @apply text-sm lowercase flex items-baseline gap-1;
-}
-
-.clearFilter {
-  @apply flex items-center hover:text-blue-600 transition-colors delay-[60ms] no-underline gap-2 text-sm cursor-pointer;
-}
-
-.closeIconSpan {
-  @apply text-white rounded-md bg-gray-500 group-hover:bg-blue-600 transition-colors delay-[60ms] w-4 h-4;
 }
 
 .searchInput {

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.store.ts
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.store.ts
@@ -6,6 +6,13 @@ const [language, setLanguage] = createSignal(defaultLanguage);
 const [sortBy, setSortBy] = createSignal(SORT_OPTIONS.default);
 const [filterType, setFilterType] = createSignal(FILTER_TYPE_OPTIONS.default);
 
+const resetFilter = () => {
+  setSearch('');
+  setLanguage(defaultLanguage);
+  setSortBy(SORT_OPTIONS.default);
+  setFilterType(FILTER_TYPE_OPTIONS.default);
+};
+
 export {
   search,
   language,
@@ -15,4 +22,5 @@ export {
   setLanguage,
   setSortBy,
   setFilterType,
+  resetFilter,
 };

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/RepoFilter.tsx
@@ -1,6 +1,11 @@
-import { createSignal, mergeProps, Show } from 'solid-js';
+import { createEffect, createSignal, mergeProps, Show } from 'solid-js';
 import { RepoBookIcon } from '../Icons';
-import { FILTER_TYPE_OPTIONS, SORT_OPTIONS } from './data';
+import {
+  defaultFilterType,
+  defaultLanguage,
+  FILTER_TYPE_OPTIONS,
+  SORT_OPTIONS,
+} from './data';
 import FilterDropdown from '../FilterDropDown/FilterDropdown';
 import FilterText from './FilterText';
 import {
@@ -10,6 +15,7 @@ import {
   setFilterType,
   sortBy,
   setSortBy,
+  search,
 } from './RepoFilter.store';
 import SearchInput from './SearchInput';
 import styles from './RepoFilter.module.css';
@@ -24,7 +30,7 @@ const RepoFilter = (props: RepoFilterProps) => {
   const typeOptions = Object.values(FILTER_TYPE_OPTIONS);
   const sortOptions = Object.values(SORT_OPTIONS);
   const languageOptions = ['All', 'HTML', 'CSS', 'PHP'];
-  const [isOnlySorted] = createSignal(true);
+  const [isOnlySorted, setIsOnlySorted] = createSignal<boolean>(true);
 
   const merged = mergeProps(
     { repoBtnText: 'New', languages: languageOptions, filteredRepoCount: 0 },
@@ -34,6 +40,17 @@ const RepoFilter = (props: RepoFilterProps) => {
   const selectLanguage = (value: string) => setLanguage(value);
   const selectType = (value: string) => setFilterType(value);
   const selectSort = (value: string) => setSortBy(value);
+
+  createEffect(() => {
+    setIsOnlySorted(
+      !!sortBy() &&
+        !(
+          language() !== defaultLanguage ||
+          filterType() !== defaultFilterType ||
+          search()
+        )
+    );
+  });
 
   return (
     <>
@@ -71,11 +88,7 @@ const RepoFilter = (props: RepoFilterProps) => {
         </div>
       </div>
       <Show when={!isOnlySorted()}>
-        <FilterText
-          filteredRepoCount={merged.filteredRepoCount}
-          setFilterType={setFilterType}
-          setLanguage={setLanguage}
-        />
+        <FilterText filteredRepoCount={merged.filteredRepoCount} />
       </Show>
     </>
   );

--- a/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/SearchInput.tsx
+++ b/solidstart-tanstackquery-tailwind-modules/src/components/RepoFilter/SearchInput.tsx
@@ -1,6 +1,6 @@
 import styles from './RepoFilter.module.css';
 import { JSX } from 'solid-js';
-import { setSearch } from './RepoFilter.store';
+import { search, setSearch } from './RepoFilter.store';
 
 const SearchInput = () => {
   const handleChange: JSX.EventHandler<HTMLInputElement, InputEvent> = (
@@ -15,6 +15,7 @@ const SearchInput = () => {
       placeholder="find a repository.."
       role="search"
       type="search"
+      value={search()}
       onInput={handleChange}
       class={styles.searchInput}
     />

--- a/solidstart-tanstackquery-tailwind-modules/vite.config.ts
+++ b/solidstart-tanstackquery-tailwind-modules/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     }
   },
   optimizeDeps: {
-    include: ['@tanstack/solid-query', 'msw', 'msw-storybook-addon']
+    include: ['@tanstack/solid-query', 'msw', 'msw-storybook-addon', 'solid-heroicons/outline', '@tanstack/query-core', 'date-fns', 'classnames']
   },
   test: {
     globals: true,


### PR DESCRIPTION
# Implement search / filter / sort result text

## Background

In another ticket, a component was created with various search and filter options. The purpose of this ticket is to dynamically update a line of text that will show below the search / filter component and above the repository list, that gives the user information on how their repositories are filtered and sorted. There should also be a “clear filter” option that shows, that when clicked, removes all filter options and hides this text section.

## Acceptance

- [x] Below the search bar and above results, should see text related to the current options
- [x] text will update based on which options are active
    - [x] search: “{number} results for repositories **matching {query}** sorted by {sort}”
    - [x] type filter: “{number} results **for {type} repositories** sorted by {sort}”
- [x] language filter:  “{number} results for repositories **written in {language}** sorted by {sort}”
    - [x] all options: “{number} results for {type} repositories matching {query} written in {language} sorted by {sort}”
    - [x] sort selection by itself does not show any text - however when any other option is selected, it will show the correct active sort value
- [x] if search or type / language filter options are selected, will always show “X clear filter” text on the right hand side, which will reset all values to default when clicked

## Notes


## Result

![Screenshot 2023-02-10 at 15 55 44](https://user-images.githubusercontent.com/28502531/218124043-e626bed4-3403-41e2-a562-66a98d530d15.jpg)
