### PR TITLE
feat(starter-dev-backend): Adds repo file tree subquery

### DIFF
--- a/starter-dev-backend/src/datasources/github-api.ts
+++ b/starter-dev-backend/src/datasources/github-api.ts
@@ -68,4 +68,11 @@ export class GitHubAPI extends RESTDataSource {
     // return repoFormatter(data);
     return data;
   }
+
+  // https://docs.github.com/rest/reference/git#get-a-tree
+  async getTree(owner: string, repoName: string) {
+    return await this.get(
+      `/repos/${owner}/${repoName}/git/trees/HEAD?recursive=1`,
+    );
+  }
 }

--- a/starter-dev-backend/src/schema/github/github.resolvers.ts
+++ b/starter-dev-backend/src/schema/github/github.resolvers.ts
@@ -23,6 +23,12 @@ export const GithubResolvers = {
       return data.name;
     },
   },
+  Repo: {
+    tree: async ({ owner, name }: any, __: any, { dataSources }: any) => {
+      const data = await dataSources.githubAPI.getTree(owner.login, name);
+      return data?.tree ?? [];
+    },
+  },
   Query: {
     repos: async (_: any, { username, perPage }: any, { dataSources }: any) => {
       const data = dataSources.githubAPI.getRepos(username, perPage);
@@ -32,7 +38,6 @@ export const GithubResolvers = {
       const data = dataSources.githubAPI.getRepo(owner, repoName);
       return data;
     },
-
     owner: async (_: any, __: any, { dataSources }: any) => {
       const data = dataSources.githubAPI.getOwner();
       return data;

--- a/starter-dev-backend/src/schema/github/github.typedefs.ts
+++ b/starter-dev-backend/src/schema/github/github.typedefs.ts
@@ -2,6 +2,17 @@ import gql from 'graphql-tag';
 
 export const githubTypeDefs = gql`
   """
+  File Tree
+  """
+  type TreeEntry {
+    path: String!
+    mode: String!
+    type: String!
+    sha: String!
+    url: String!
+  }
+
+  """
   A Repo object
   """
   type Repo {
@@ -16,6 +27,7 @@ export const githubTypeDefs = gql`
     stargazers_count: Int
     title: String
     updated_at: String
+    tree: [TreeEntry]!
   }
 
   """

--- a/starter-dev-backend/types/graphql.ts
+++ b/starter-dev-backend/types/graphql.ts
@@ -14,7 +14,7 @@ export type Scalars = {
   Float: number;
 };
 
-/** A Organization object used in Owner */
+/** An Organization object used in Owner */
 export type Orgs = {
   __typename?: 'Orgs';
   avatar_url?: Maybe<Scalars['String']>;
@@ -24,7 +24,7 @@ export type Orgs = {
   repos_url?: Maybe<Scalars['String']>;
 };
 
-/** A User object */
+/** An Owner object */
 export type Owner = {
   __typename?: 'Owner';
   bio?: Maybe<Scalars['String']>;
@@ -83,10 +83,21 @@ export type Repo = {
   private?: Maybe<Scalars['Boolean']>;
   stargazers_count?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
+  tree: Array<Maybe<TreeEntry>>;
   updated_at?: Maybe<Scalars['String']>;
 };
 
-/** An Owner object used in Repo */
+/** File Tree */
+export type TreeEntry = {
+  __typename?: 'TreeEntry';
+  mode: Scalars['String'];
+  path: Scalars['String'];
+  sha: Scalars['String'];
+  type: Scalars['String'];
+  url: Scalars['String'];
+};
+
+/** A User object used in Repo */
 export type User = {
   __typename?: 'User';
   login?: Maybe<Scalars['String']>;
@@ -169,6 +180,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   Repo: ResolverTypeWrapper<Repo>;
   String: ResolverTypeWrapper<Scalars['String']>;
+  TreeEntry: ResolverTypeWrapper<TreeEntry>;
   User: ResolverTypeWrapper<User>;
 };
 
@@ -182,6 +194,7 @@ export type ResolversParentTypes = {
   Query: {};
   Repo: Repo;
   String: Scalars['String'];
+  TreeEntry: TreeEntry;
   User: User;
 };
 
@@ -227,7 +240,17 @@ export type RepoResolvers<ContextType = any, ParentType extends ResolversParentT
   private?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   stargazers_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tree?: Resolver<Array<Maybe<ResolversTypes['TreeEntry']>>, ParentType, ContextType>;
   updated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type TreeEntryResolvers<ContextType = any, ParentType extends ResolversParentTypes['TreeEntry'] = ResolversParentTypes['TreeEntry']> = {
+  mode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sha?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -241,6 +264,7 @@ export type Resolvers<ContextType = any> = {
   Owner?: OwnerResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Repo?: RepoResolvers<ContextType>;
+  TreeEntry?: TreeEntryResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
 


### PR DESCRIPTION
## Details

This PR adds a tree subquery on the Repo type that returns a recursive lookup of the entire repo file tree at HEAD. See the test in GraphQL explorer in the screenshot. This will allow users of our GH GraphQL API to create the entire file explorer from their request on the repo query. 

Closes #893 

![Screen Shot 2023-02-16 at 3 00 43 PM](https://user-images.githubusercontent.com/3721977/219475733-6871035c-f565-4bcb-a7ce-b46f2e2a2f70.png)
