### PR TITLE
responsiveness completed

### DIFF
--- a/expo-zustand-styled-components/src/components/RepoActionButtons/RepoActionButtons.styles.ts
+++ b/expo-zustand-styled-components/src/components/RepoActionButtons/RepoActionButtons.styles.ts
@@ -7,11 +7,12 @@ type ScreenWidth = {
 };
 
 export const Container = styled.View<ScreenWidth>`
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   flex-direction: row;
   justify-content: space-between;
-  width: ${({ screenWidth }) => (screenWidth >= breakpoints.tablet ? '21%' : '100%')};
+  width: ${({ screenWidth }) => (screenWidth >= breakpoints.tablet ? 'none' : '100%')};
+  gap: 16px;
 `;
 
 export const BtnGroup = styled.View`

--- a/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.styles.ts
+++ b/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.styles.ts
@@ -11,6 +11,7 @@ export const Heading = styled.View<ScreenWidth>`
   overflow: hidden;
   flex-direction: row;
   align-items: center;
+  overflow: scroll;
   width: ${({ screenWidth }) => (screenWidth >= breakpoints.tablet ? '50%' : '100%')};
 `;
 
@@ -21,7 +22,7 @@ export const RepoContentWrapper = styled.View<ScreenWidth>`
       return `
         justify-content: center;
       `;
-    }else{
+    } else {
       return `
         align-items: flex-start;
       `;


### PR DESCRIPTION
# Description
- Currently, the repo sub-header is not responsive.



![Image](https://user-images.githubusercontent.com/1828602/227211624-ed52c477-a823-4808-8251-aa01e556037b.png)




![Screenshot 2023-03-24 at 15 18 52](https://user-images.githubusercontent.com/28502531/227551819-9f05d189-c30c-496f-99ee-ac8154eac162.jpg)
