### PR TITLE
handled loading state properly should incase log in fails

### DIFF
--- a/expo-zustand-styled-components/src/screens/Login/Login.tsx
+++ b/expo-zustand-styled-components/src/screens/Login/Login.tsx
@@ -30,7 +30,10 @@ const Login = ({ navigation }: RootStackScreenProps<'AuthNavigator'>) => {
       // TODO: this is a hacky way to get the access_token from the url that works for both web and mobile
       const access_token = url.toString().split('access_token=')[1];
       useAuthStore.setState({ token: access_token, isLoading: false });
+    } else {
+      useAuthStore.setState({isLoading: false });
     }
+
   };
 
   useEffect(() => {
@@ -48,6 +51,7 @@ const Login = ({ navigation }: RootStackScreenProps<'AuthNavigator'>) => {
         title="Sign in with GitHub"
         loadingText="Loging in..."
         onPress={_handlePressButtonAsync}
+        disabled={isLoading}
       />
     </SafeAreaViewStyled>
   );


### PR DESCRIPTION
# Description
- the sign in button is currently tied to its loading state which creates a scenario where a user attempts to login and fails, the button is still clickable and no error is presented putting the user in limbo.
- There is a need to handle failed login error, at the moment, the loading state remains and the button can still be clicked in its loading state