### PR TITLE
open and closed count fixed and empty filter content handled

### DIFF
--- a/expo-zustand-styled-components/src/components/IssuesTabView/IssuesTabView.styles.ts
+++ b/expo-zustand-styled-components/src/components/IssuesTabView/IssuesTabView.styles.ts
@@ -31,3 +31,8 @@ export const PaginationBtn = styled.TouchableOpacity`
   align-items: center;
   gap: 8px;
 `;
+
+export const EmptyIssue = styled.View`
+  align-items: center;
+  padding: 16px;
+`;

--- a/expo-zustand-styled-components/src/components/IssuesTabView/IssuesTabView.tsx
+++ b/expo-zustand-styled-components/src/components/IssuesTabView/IssuesTabView.tsx
@@ -1,7 +1,7 @@
 import PRAndIssueHeader from '../PRAndIssueHeader';
-import { ContentContainer, MainContainer } from './IssuesTabView.styles';
+import { ContentContainer, MainContainer, EmptyIssue } from './IssuesTabView.styles';
 import IssuePullRequestCard from '../IssuePullRequestCard';
-import { useWindowDimensions } from 'react-native';
+import { Text, useWindowDimensions } from 'react-native';
 import { useIssuesStore, usePRAndIssueHeaderStore } from '../../hooks/stores';
 import { SORT_OPTIONS } from '../../utils/constants';
 import IssuesPRClearFilter from '../IssuesPRClearFilter';
@@ -42,6 +42,12 @@ const IssuesTabView = () => {
         {issues[activeTab + 'Issues'].issues.map((data, index) => (
           <IssuePullRequestCard {...data} cardType="issue" key={index} />
         ))}
+
+        {selectedIssue.issues.length === 0 && (
+          <EmptyIssue>
+            <Text style={{ textTransform: 'uppercase' }}>No {activeTab} Issues found.</Text>
+          </EmptyIssue>
+        )}
       </ContentContainer>
       <Pagination
         hasPrevPage={hasPrevPage ? true : false}

--- a/expo-zustand-styled-components/src/components/PRAndIssueHeader/PRAndIssueHeader.tsx
+++ b/expo-zustand-styled-components/src/components/PRAndIssueHeader/PRAndIssueHeader.tsx
@@ -66,11 +66,15 @@ const PRAndIssueHeader = ({ cardType, openCount, closedCount }: PRAndIssueHeader
           ) : (
             <IssuesIcon color={colors.gray500} style={{ marginRight: 4 }} />
           )}
-          <TabText isActive={activeTab === PR_ISSUE_TABS.open}>{openCount}</TabText>
+          {openCount > 0 && (
+            <TabText isActive={activeTab === PR_ISSUE_TABS.open}>{openCount}</TabText>
+          )}
           <TabText isActive={activeTab === PR_ISSUE_TABS.open}>Open</TabText>
         </Tab>
         <Tab activeOpacity={0.7} onPress={() => handleTabPress(PR_ISSUE_TABS.closed)}>
-          <TabText isActive={activeTab === PR_ISSUE_TABS.closed}>{closedCount}</TabText>
+          {closedCount > 0 && (
+            <TabText isActive={activeTab === PR_ISSUE_TABS.closed}>{closedCount}</TabText>
+          )}
           <TabText isActive={activeTab === PR_ISSUE_TABS.closed}>Closed</TabText>
         </Tab>
       </Tabs>

--- a/expo-zustand-styled-components/src/components/PullRequestsTabView/PullRequestsTabView.styles.ts
+++ b/expo-zustand-styled-components/src/components/PullRequestsTabView/PullRequestsTabView.styles.ts
@@ -31,3 +31,8 @@ export const PaginationBtn = styled.TouchableOpacity`
   align-items: center;
   gap: 8px;
 `;
+
+export const EmptyPullRequest = styled.View`
+  align-items: center;
+  padding: 16px;
+`;

--- a/expo-zustand-styled-components/src/components/PullRequestsTabView/PullRequestsTabView.tsx
+++ b/expo-zustand-styled-components/src/components/PullRequestsTabView/PullRequestsTabView.tsx
@@ -1,11 +1,12 @@
 import PRAndIssueHeader from '../PRAndIssueHeader';
-import { ContentContainer, MainContainer } from './PullRequestsTabView.styles';
+import { ContentContainer, MainContainer, EmptyPullRequest } from './PullRequestsTabView.styles';
 import IssuePullRequestCard from '../IssuePullRequestCard';
 import { useWindowDimensions } from 'react-native';
 import { usePRAndIssueHeaderStore, usePullRequestsStore } from '../../hooks/stores';
 import { SORT_OPTIONS } from '../../utils/constants';
 import IssuesPRClearFilter from '../IssuesPRClearFilter';
 import Pagination from '../Pagination';
+import { Text } from 'react-native';
 
 const PullRequestsTabView = () => {
   const { activeTab, label, sortBy } = usePRAndIssueHeaderStore();
@@ -42,9 +43,14 @@ const PullRequestsTabView = () => {
           openCount={pullRequests.openPullRequests.totalCount}
           closedCount={pullRequests.closedPullRequests.totalCount}
         />
-        {pullRequests[activeTab + 'PullRequests'].pullRequests.map((data, index) => (
+        {selectedPullRequests.pullRequests.map((data, index) => (
           <IssuePullRequestCard {...data} cardType="pr" key={index} />
         ))}
+        {selectedPullRequests.pullRequests.length === 0 && (
+          <EmptyPullRequest>
+            <Text style={{textTransform: 'uppercase'}}>No {activeTab} Pull Request found.</Text>
+          </EmptyPullRequest>
+        )}
       </ContentContainer>
       <Pagination
         hasPrevPage={hasPrevPage ? true : false}

--- a/expo-zustand-styled-components/src/screens/Repository/Issues/Issues.tsx
+++ b/expo-zustand-styled-components/src/screens/Repository/Issues/Issues.tsx
@@ -36,7 +36,7 @@ const Issues = () => {
 
   useEffect(() => {
     getIssues(fetchParameters());
-  }, [before, after, sortBy, milestone, label]);
+  }, [before, after, sortBy, milestone, label, owner, name]);
 
   return (
     <Wrapper>

--- a/expo-zustand-styled-components/src/screens/Repository/Pull-Requests/Pull-Requests.tsx
+++ b/expo-zustand-styled-components/src/screens/Repository/Pull-Requests/Pull-Requests.tsx
@@ -36,7 +36,7 @@ const PullRequests = () => {
 
   useEffect(() => {
     getRepoPullRequests(fetchParameters());
-  }, [before, sortBy, label, after]);
+  }, [before, sortBy, label, after, owner, name]);
   return (
     <Wrapper>
       {isLoading ? <PRAndIssueLoaderSkeleton cardType="pr" /> : <PullRequestsTabView />}


### PR DESCRIPTION
# Description
- on the issues and on the pr page, when I navigate through pages every time I am in a query loading status the total count number for open and closed issues or pr goes to zero, and then when the query is in the success status we see it again. That number should be fixed and not dependent on all the query statuses.



![Image](https://user-images.githubusercontent.com/1828602/227976553-e487755a-47ea-4677-9727-63a8d0e03f9d.png)

