### PR TITLE
something might be wrong with how zustand store hook works

### DIFF
--- a/expo-zustand-styled-components/src/components/UserDropdown/UserDropdown.tsx
+++ b/expo-zustand-styled-components/src/components/UserDropdown/UserDropdown.tsx
@@ -24,7 +24,7 @@ const UserDropdown = ({
 
   return (
     <DropdownWrapper>
-      <ProfileImageWrapper testID="profile-image" onPress={() => toggleMenu()}>
+      <ProfileImageWrapper testID="profile-image" onPress={() => useAuthStore.setState({isMenuOpen: !isMenuOpen})}>
         <ProfileImage source={{ uri: viewer?.avatarUrl || '' }} />
         <ArrowImage source={require('../../../assets/arrow-down-icon.png')} />
       </ProfileImageWrapper>


### PR DESCRIPTION
# Description
- The first time you log in and click the profile dropdown on the header, the dropdown doesn't show until you refresh the page.
I believe this is due to how the toggle is handled.