### PR TITLE
fix repo card title

### DIFF
--- a/expo-zustand-styled-components/src/components/RepoCard/RepoCard.tsx
+++ b/expo-zustand-styled-components/src/components/RepoCard/RepoCard.tsx
@@ -28,12 +28,18 @@ interface RepoCardProps {
 const RepoCard = ({ repo, isProfilePage }: RepoCardProps) => {
   const { width } = useWindowDimensions();
 
+  const repoNameWithOwnerLink = () =>
+    repo.owner?.login ? `/${repo.owner.login}/${repo.name || ''}` : '';
+
+  const repoNameWithOwner = () =>
+    `${!isProfilePage ? `${repo.owner?.login + '/' || ''}` : ''}${repo.name || ''}`;
+
   return (
     <Card>
       <Content>
         <Heading>
-          <LinkButton to={`/${repo.owner.login}/${repo.name}`} hasLine>
-            <LinkText screenWidth={width}>{repo.name}</LinkText>
+          <LinkButton to={repoNameWithOwnerLink()} hasLine>
+            <LinkText screenWidth={width}>{repoNameWithOwner()}</LinkText>
           </LinkButton>
           <PrivacyBadge visibility={repo.visibility} />
         </Heading>


### PR DESCRIPTION
# Decription
- The repo title displays incorrectly 

![Image](https://user-images.githubusercontent.com/1828602/228528970-b28156c6-4d93-4aa8-8bd7-cd8d3e4eeb8c.png)

But should be like this owner/reponame

![Image](https://user-images.githubusercontent.com/1828602/228529186-e9e8bce6-559a-4b71-a3bf-0550615cc37a.png)





## result

![Screenshot 2023-03-29 at 13 40 10](https://user-images.githubusercontent.com/28502531/228538686-4be4b4db-020f-4cc1-9c0b-02682fdf758d.jpg)
