### PR TITLE
added a check to know the repo is for an org or just a user.

### DIFF
--- a/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.tsx
@@ -24,11 +24,9 @@ const RepoHeading = () => {
   return (
     <Heading screenWidth={width}>
       <PrivacyIcon visibility={info?.visibility} />
-      <RepoContentWrapper
-        screenWidth={width}
-        >
+      <RepoContentWrapper screenWidth={width}>
         <HeadingContent screenWidth={width}>
-          <LinkButton to={`/orgs/${owner}`} hasLine>
+          <LinkButton to={info?.isOrg ? `/orgs/${owner}` : `/${owner}`} hasLine>
             <OwnerLink screenWidth={width}>{owner}</OwnerLink>
           </LinkButton>
           {width > breakpoints.mobile ? <Separator>/</Separator> : null}


### PR DESCRIPTION
Closes: #1712

# Description
- clicking on the repo owner doesn't load the page. We need to check if the repo is for an org or just a user.


![Image](https://user-images.githubusercontent.com/1828602/228721414-656eec6a-e723-4a9d-8017-1176fa1ae2d4.png)


https://user-images.githubusercontent.com/36667083/228729721-3dff2ecb-614c-4c5b-a9f6-1e56e0586e85.mp4

