### PR TITLE
test for repo heading and privacy icon

### DIFF
--- a/expo-zustand-styled-components/src/components/LinkButton/LinkButton.tsx
+++ b/expo-zustand-styled-components/src/components/LinkButton/LinkButton.tsx
@@ -10,6 +10,7 @@ interface LinkButtonProps {
   onClick?: () => void;
   hasLine?: boolean;
   children: ReactNode;
+  testID?: string;
   style?: StyleProp<ViewStyle>;
 }
 

--- a/expo-zustand-styled-components/src/components/PrivacyBadge/PrivacyBadge.tsx
+++ b/expo-zustand-styled-components/src/components/PrivacyBadge/PrivacyBadge.tsx
@@ -8,7 +8,7 @@ interface PrivacyBadgeProps {
 const PrivacyBadge = ({ visibility }: PrivacyBadgeProps) => {
   const { width } = useWindowDimensions();
   return (
-    <Badge>
+    <Badge testID="privacy-badge">
       <BadgeText screenWidth={width}>{visibility.toLowerCase()}</BadgeText>
     </Badge>
   );

--- a/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
@@ -7,27 +7,27 @@ describe('PrivacyIcon component', () => {
     render(<PrivacyIcon visibility="private" />);
   });
 
-//   it('renders PadlockIcon for private visibility', () => {
-//     const { getByTestId } = render(<PrivacyIcon visibility="private" />);
-//     const padlockIcon = getByTestId('padlock-icon');
-//     expect(padlockIcon).toBeDefined();
-//   });
+  it('renders PadlockIcon for private visibility', () => {
+    const { getByTestId } = render(<PrivacyIcon visibility="private" />);
+    const padlockIcon = getByTestId('padlock-icon');
+    expect(padlockIcon).toBeDefined();
+  });
 
-//   it('renders RepoIcon for public visibility', () => {
-//     const { getByTestId } = render(<PrivacyIcon visibility="public" />);
-//     const repoIcon = getByTestId('repo-icon');
-//     expect(repoIcon).toBeDefined();
-//   });
+  it('renders RepoIcon for public visibility', () => {
+    const { getByTestId } = render(<PrivacyIcon visibility="public" />);
+    const repoIcon = getByTestId('repo-icon');
+    expect(repoIcon).toBeDefined();
+  });
 
-//   it('renders IconPlaceholder for falsy visibility prop', () => {
-//     const { getByTestId } = render(<PrivacyIcon visibility={null} />);
-//     const iconPlaceholder = getByTestId('icon-placeholder');
-//     expect(iconPlaceholder).toBeDefined();
-//   });
+  it('renders IconPlaceholder for falsy visibility prop', () => {
+    const { getByTestId } = render(<PrivacyIcon visibility={null} />);
+    const iconPlaceholder = getByTestId('icon-placeholder');
+    expect(iconPlaceholder).toBeDefined();
+  });
 
-//   it('passes the correct color prop to the rendered icon', () => {
-//     const { getByTestId } = render(<PrivacyIcon visibility="private" />);
-//     const padlockIcon = getByTestId('padlock-icon');
-//     expect(padlockIcon.props.color).toBe('#8b8b8b');
-//   });
+  it('passes the correct color prop to the rendered icon', () => {
+    const { getByTestId } = render(<PrivacyIcon visibility="private" />);
+    const padlockIcon = getByTestId('padlock-icon');
+    expect(padlockIcon.props.color).toBe('#8b8b8b');
+  });
 });

--- a/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
@@ -24,10 +24,4 @@ describe('PrivacyIcon component', () => {
     const iconPlaceholder = getByTestId('icon-placeholder');
     expect(iconPlaceholder).toBeDefined();
   });
-
-  it('passes the correct color prop to the rendered icon', () => {
-    const { getByTestId } = render(<PrivacyIcon visibility="private" />);
-    const padlockIcon = getByTestId('padlock-icon');
-    expect(padlockIcon.props.color).toBe('#8b8b8b');
-  });
 });

--- a/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import PrivacyIcon from './PrivacyIcon';
+
+describe('PrivacyIcon component', () => {
+  it('renders without errors', () => {
+    render(<PrivacyIcon visibility="private" />);
+  });
+
+//   it('renders PadlockIcon for private visibility', () => {
+//     const { getByTestId } = render(<PrivacyIcon visibility="private" />);
+//     const padlockIcon = getByTestId('padlock-icon');
+//     expect(padlockIcon).toBeDefined();
+//   });
+
+//   it('renders RepoIcon for public visibility', () => {
+//     const { getByTestId } = render(<PrivacyIcon visibility="public" />);
+//     const repoIcon = getByTestId('repo-icon');
+//     expect(repoIcon).toBeDefined();
+//   });
+
+//   it('renders IconPlaceholder for falsy visibility prop', () => {
+//     const { getByTestId } = render(<PrivacyIcon visibility={null} />);
+//     const iconPlaceholder = getByTestId('icon-placeholder');
+//     expect(iconPlaceholder).toBeDefined();
+//   });
+
+//   it('passes the correct color prop to the rendered icon', () => {
+//     const { getByTestId } = render(<PrivacyIcon visibility="private" />);
+//     const padlockIcon = getByTestId('padlock-icon');
+//     expect(padlockIcon.props.color).toBe('#8b8b8b');
+//   });
+});

--- a/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.tsx
@@ -9,13 +9,13 @@ interface PrivacyIconProps {
   visibility: string;
 }
 const PrivacyIcon = ({ visibility }: PrivacyIconProps) => {
-  const isPrivate = 'private'.localeCompare(visibility) > 0;
+  const isPrivate = 'private'.localeCompare(visibility) === 0;
 
-  if (!visibility) <IconPlaceholder />;
+  if (!visibility) <IconPlaceholder testID='icon-placeholder' />;
 
   return (
-    <View>
-      {isPrivate ? <PadlockIcon color={colors.gray400} /> : <RepoIcon color={colors.gray400} />}
+    <View testID='privacy-icon'>
+      {isPrivate ? <PadlockIcon testID="padlock-icon" color={colors.gray400} /> : <RepoIcon testID="repo-icon" color={colors.gray400} />}
     </View>
   );
 };

--- a/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/PrivacyIcon.tsx
@@ -11,7 +11,7 @@ interface PrivacyIconProps {
 const PrivacyIcon = ({ visibility }: PrivacyIconProps) => {
   const isPrivate = 'private'.localeCompare(visibility) === 0;
 
-  if (!visibility) <IconPlaceholder testID='icon-placeholder' />;
+  if (!visibility) return <IconPlaceholder testID='icon-placeholder' />;
 
   return (
     <View testID='privacy-icon'>

--- a/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.spec.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.spec.tsx
@@ -1,0 +1,69 @@
+import { render } from '@testing-library/react-native';
+import { useRepoInfoStore } from '../../hooks/stores';
+import RepoHeading from './RepoHeading';
+
+jest.mock('../../hooks/stores', () => ({
+  useRepoInfoStore: jest.fn(),
+}));
+
+describe('RepoHeading', () => {
+  const mockUseRepoInfoStore = useRepoInfoStore as jest.MockedFunction<typeof useRepoInfoStore>;
+
+  beforeEach(() => {
+    mockUseRepoInfoStore.mockReturnValue({
+      name: 'my-repo',
+      owner: 'my-org',
+      info: { visibility: 'public', isOrg: false },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render', () => {
+    const { container } = render(<RepoHeading />);
+    expect(container).toBeTruthy();
+  });
+
+  it('renders the owner link to have an onClick function', () => {
+    const { getByTestId } = render(<RepoHeading />);
+    const ownerLink = getByTestId('owner-link');
+    expect(ownerLink.props.onClick).toBeTruthy();
+  });
+
+  it('renders the owner text with the correct text', () => {
+    const { getByTestId } = render(<RepoHeading />);
+    const ownerText = getByTestId('owner-text');
+    expect(ownerText.props.children).toBe('my-org');
+  });
+
+  it('renders the name link to have an onClick function', () => {
+    const { getByTestId } = render(<RepoHeading />);
+    const nameLink = getByTestId('name-link');
+    expect(nameLink.props.onClick).toBeTruthy();
+  });
+
+  it('renders the name text with the correct text', () => {
+    const { getByTestId } = render(<RepoHeading />);
+    const nameText = getByTestId('name-text');
+    expect(nameText.props.children).toBe('my-repo');
+  });
+
+  it('renders the PrivacyBadge component when info.visibility is truthy', () => {
+    const { getByTestId } = render(<RepoHeading />);
+    const privacyBadge = getByTestId('privacy-badge');
+    expect(privacyBadge).toBeDefined();
+  });
+
+  it('does not render the PrivacyBadge component when info.visibility is falsy', () => {
+    mockUseRepoInfoStore.mockReturnValue({
+      name: 'my-repo',
+      owner: 'my-org',
+      info: { visibility: null, isOrg: false },
+    });
+    const { queryByTestId } = render(<RepoHeading />);
+    const privacyBadge = queryByTestId('privacy-badge');
+    expect(privacyBadge).toBeNull();
+  });
+});

--- a/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.tsx
+++ b/expo-zustand-styled-components/src/components/RepoHeading/RepoHeading.tsx
@@ -26,12 +26,14 @@ const RepoHeading = () => {
       <PrivacyIcon visibility={info?.visibility} />
       <RepoContentWrapper screenWidth={width}>
         <HeadingContent screenWidth={width}>
-          <LinkButton to={info?.isOrg ? `/orgs/${owner}` : `/${owner}`} hasLine>
-            <OwnerLink screenWidth={width}>{owner}</OwnerLink>
+          <LinkButton testID="owner-link" to={info?.isOrg ? `/orgs/${owner}` : `/${owner}`} hasLine>
+            <OwnerLink testID="owner-text" screenWidth={width}>
+              {owner}
+            </OwnerLink>
           </LinkButton>
           {width > breakpoints.mobile ? <Separator>/</Separator> : null}
-          <LinkButton to={`/${owner}/${name}`} hasLine>
-            <NameLink screenWidth={width} numberOfLines={1}>
+          <LinkButton testID="name-link" to={`/${owner}/${name}`} hasLine>
+            <NameLink testID="name-text" screenWidth={width} numberOfLines={1}>
               {name}
             </NameLink>
           </LinkButton>


### PR DESCRIPTION
Close: #1741

Found a bug and fixed it `const isPrivate = 'private'.localeCompare(visibility) > 0;`