### PR TITLE
update LinkButton to handle targe='_blank'

### DIFF
--- a/expo-zustand-styled-components/src/components/IssuePullRequestCard/IssuePullRequestCard.tsx
+++ b/expo-zustand-styled-components/src/components/IssuePullRequestCard/IssuePullRequestCard.tsx
@@ -30,6 +30,7 @@ import { getTextColor } from '../../utils/dynamicColor';
 import { colors } from '../../utils/style-variables';
 
 import { Issue } from '../../types/issues-type';
+import LinkButton from '../LinkButton/LinkButton';
 
 const IssuePullRequestCard = ({
   url,
@@ -74,9 +75,9 @@ const IssuePullRequestCard = ({
       <View>{getIcon()}</View>
       <Content>
         <TitleLabelsWrapper>
-          <Link to={url}>
+          <LinkButton to={url} isBlank>
             <ContentTitle>{title}</ContentTitle>
-          </Link>
+          </LinkButton>
           <Labels>
             {labels.map(({ color, name }, index) => (
               <LabelView key={index} color={color}>

--- a/expo-zustand-styled-components/src/components/LinkButton/LinkButton.tsx
+++ b/expo-zustand-styled-components/src/components/LinkButton/LinkButton.tsx
@@ -12,9 +12,17 @@ interface LinkButtonProps {
   children: ReactNode;
   testID?: string;
   style?: StyleProp<ViewStyle>;
+  isBlank?: boolean;
 }
 
-const LinkButton = ({ to, children, hasLine = false, onClick, ...rest }: LinkButtonProps) => {
+const LinkButton = ({
+  to,
+  children,
+  hasLine = false,
+  onClick,
+  isBlank,
+  ...rest
+}: LinkButtonProps) => {
   const { onPress, ...props } = useLinkProps({ to });
 
   const [isHovered, setIsHovered] = useState(false);
@@ -26,9 +34,14 @@ const LinkButton = ({ to, children, hasLine = false, onClick, ...rest }: LinkBut
     // You can add hover effects using `onMouseEnter` and `onMouseLeave`
     return (
       <View
-        onClick={() => {
-          onClick && onClick();
-          onPress();
+        onClick={(e: Event) => {
+          if (isBlank) {
+            e.preventDefault();
+            window.open(to, '_blank');
+          } else {
+            onClick && onClick();
+            onPress();
+          }
         }}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}


### PR DESCRIPTION
Closes: #1802

- added an `isBlank` props to handle the link to open in another tab, wasn't able to set target="_blank" directly
- updated issues and PR Link to open in a new tab.