### PR TITLE
get top repos api

### DIFF
--- a/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
+++ b/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
@@ -1,0 +1,13 @@
+import { UseFetchOptions } from "nuxt/app";
+
+export default function useFetchAPI(url: string, opts?: UseFetchOptions<unknown>) {
+	const config = useRuntimeConfig();
+	const { GITHUB_API_URL } = config;
+	const token = useCookie('token');
+	const headers = {
+		...(opts?.headers || {}),
+		...(token && { Authorization: `Bearer ${token.value}` }),
+	};
+
+	return useFetch(url, { ...opts, headers, baseURL: GITHUB_API_URL });
+}

--- a/nuxt3-pinia-vuetify/nuxt.config.ts
+++ b/nuxt3-pinia-vuetify/nuxt.config.ts
@@ -13,9 +13,6 @@ export default defineNuxtConfig({
 			'process.env.DEBUG': false,
 		},
 	},
-	axios: {
-		baseURL: process.env.GITHUB_API_URL,
-	},
 	runtimeConfig: {
 		public: {
 			GITHUB_API_URL: process.env.GITHUB_API_URL,

--- a/nuxt3-pinia-vuetify/store/userStore.ts
+++ b/nuxt3-pinia-vuetify/store/userStore.ts
@@ -1,0 +1,39 @@
+import useFetchAPI from "~~/hooks/useFetchApI";
+import { IRepository } from "~~/types/interfaces";
+
+export interface IUserRootState {
+	topRepos: IRepository[];
+}
+
+export const useUserStore = defineStore('userStore', {
+	state: (): IUserRootState => ({
+		topRepos: [],
+	}),
+	actions: {
+		async getUserTopRepos() {
+			try {
+				const url = `/user/repos`;
+				const { data } = await useFetchAPI(url, {
+					headers: {
+						Accept: 'application/vnd.github+json',
+					},
+					params: {
+						sort: 'updated',
+						affiliation: 'owner, collaborator, organization_member',
+						per_page: '20',
+					},
+				});
+
+				const topRepos = data.value as IRepository[];
+				this.topRepos = topRepos;
+
+			} catch (error: any) {
+				if (error && error?.response) {
+					throw error;
+				}
+
+				throw new Error('Error fetching user top repos');
+			}
+		},
+	},
+});

--- a/nuxt3-pinia-vuetify/types/interfaces.ts
+++ b/nuxt3-pinia-vuetify/types/interfaces.ts
@@ -1,0 +1,22 @@
+export interface IRepository {
+	id: number;
+	name: string;
+	full_name: string;
+	owner: { login: string };
+	description: string;
+	private: boolean;
+	html_url: string;
+	url: string;
+	updated_at: Date;
+	stargazers_count: number;
+	language: string;
+	branches_url: string;
+	visibility: 'public' | 'private';
+	subscribers_count: number;
+	forks_count: number;
+	open_issues_count: number;
+	pulls: number;
+	default_branch: string;
+	homepage: string;
+	watchers_count: number;
+}


### PR DESCRIPTION
## Background

Like the actual GitHub dashboard, we want to show a user their top repositories. The actual dashboard shows some other information, such as event feeds, but these aren’t available via the API easily so we opted for top repositories instead.

## Acceptance

- [x] Get top repositories from GitHub API
- [x] For display on main page; data needed:
    - [x] Repo name
    - [x] description
    - [x] language
    - [x] star count
    - [x] fork count
    - [x] last updated
    - [x] visibility tag (public / private)

## Notes

- If you’re using the GraphQL API, there’s a TopRepositories query you can run to retrieve this information easily. (example [GraphQL](angular-apollo-tailwind/src/app/gql/queries/user-top-repos.query.gql) )
- If you’re using the REST API, an equivalent query doesn’t exist. We’ve opted to use the following request instead. (example [rest API](angular-ngrx-scss/src/app/user/services/user.service.ts))