### PR TITLE
Feat profile api

### DIFF
--- a/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
+++ b/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
@@ -1,6 +1,6 @@
 import { UseFetchOptions } from "nuxt/app";
 
-export default function useFetchAPI(url: string, opts?: UseFetchOptions<unknown>) {
+export default function useFetchAPI(url: string, opts?: UseFetchOptions<Record<string, any>>): Record<string, any> {
 	const config = useRuntimeConfig();
 	const { GITHUB_API_URL } = config;
 	const token = useCookie('token');

--- a/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
+++ b/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
@@ -1,6 +1,6 @@
 import { UseFetchOptions } from "nuxt/app";
 
-export default function useFetchAPI(url: string, opts?: UseFetchOptions<Record<string, any>>): Record<string, any> {
+export default function useFetchAPI<T>(url: string, opts?: UseFetchOptions<Record<string, any>>): Record<string, any> | { data: T } {
 	const config = useRuntimeConfig();
 	const { GITHUB_API_URL } = config;
 	const token = useCookie('token');

--- a/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
+++ b/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
@@ -1,0 +1,13 @@
+import { UseFetchOptions } from "nuxt/app";
+
+export default function useFetchAPI(url: string, opts?: UseFetchOptions<unknown>) {
+	const config = useRuntimeConfig();
+	const { GITHUB_API_URL } = config;
+	const token = useCookie('token');
+	const headers = {
+		...(opts?.headers || {}),
+		...(token && { Authorization: `Bearer ${token.value}` }),
+	};
+
+	return useFetch(url, { ...opts, headers, baseURL: GITHUB_API_URL });
+}

--- a/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
+++ b/nuxt3-pinia-vuetify/hooks/useFetchApI.ts
@@ -1,6 +1,9 @@
-import { UseFetchOptions } from "nuxt/app";
+import { UseFetchOptions } from 'nuxt/app';
 
-export default function useFetchAPI<T>(url: string, opts?: UseFetchOptions<Record<string, any>>): Record<string, any> | { data: T } {
+export default function useFetchAPI<T>(
+	url: string,
+	opts?: UseFetchOptions<Record<string, any>>
+): Record<string, any> | { data: T } {
 	const config = useRuntimeConfig();
 	const { GITHUB_API_URL } = config;
 	const token = useCookie('token');

--- a/nuxt3-pinia-vuetify/pages/index.vue
+++ b/nuxt3-pinia-vuetify/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useProfileStore } from '~/store/profileStore';
 useHead({
 	title: 'Nuxt 3, Pinia and Vuetify',
 	meta: [
@@ -11,6 +12,8 @@ useHead({
 definePageMeta({
 	middleware: ['auth']
 })
+const profileStore = useProfileStore();
+profileStore.getAuthUser();
 </script>
 
 <template>

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -17,7 +17,7 @@ export const useProfileStore = defineStore('profileStore', {
 		async getProfile() {
 			try {
 				const url = `/users/${this.login}`;
-				const { data } = await useFetchAPI(url, {
+				const { data } = await useFetchAPI<IUser>(url, {
 					headers: {
 						Accept: 'application/vnd.github+json',
 					},
@@ -28,11 +28,12 @@ export const useProfileStore = defineStore('profileStore', {
 				this.user = resp;
 				const companyURL = resp.organizations_url;
 
-				const { data: companyData } = await useFetchAPI<IUserOrg>(companyURL, {
-					headers: {
-						Accept: 'application/vnd.github+json',
-					},
-				});
+				const { data: companyData } =
+					await useFetchAPI<IUserOrg>(companyURL, {
+						headers: {
+							Accept: 'application/vnd.github+json',
+						},
+					});
 
 				const orgs = companyData.value;
 

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -1,8 +1,8 @@
-import useFetchAPI from "~~/hooks/useFetchApI";
-import { IUserApiResponse } from "~~/types/users/interface";
+import useFetchAPI from '~~/hooks/useFetchApI';
+import { IUser, IUserOrg } from '~~/types/users/interface';
 
 export interface IProfileRootState {
-	user: IUserApiResponse | null;
+	user: IUser | null;
 	login: string | null;
 	avatar_url: string | null;
 }
@@ -23,7 +23,26 @@ export const useProfileStore = defineStore('profileStore', {
 					},
 				});
 
-				this.user = data.value as IUserApiResponse;
+				const resp = data.value as IUser;
+
+				this.user = resp;
+				const companyURL = resp.organizations_url;
+
+				const { data: companyData } = await useFetchAPI(
+					companyURL,
+					{
+						headers: {
+							Accept: 'application/vnd.github+json',
+						},
+					}
+				);
+
+				const orgs = companyData.value as IUserOrg[];
+
+				this.user = {
+					...this.user,
+					orgs,
+				};
 			} catch (error: any) {
 				if (error && error?.response) {
 					throw error;

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -1,8 +1,8 @@
 import useFetchAPI from '~~/hooks/useFetchApI';
-import { IUser, IUserOrg } from '~~/types/users/interface';
+import { IUser } from '~~/types/users/interface';
 
 export interface IProfileRootState {
-	user: IUser | null;
+	user: IUser | Record<string, any> | null;
 	login: string | null;
 	avatar_url: string | null;
 }
@@ -23,21 +23,19 @@ export const useProfileStore = defineStore('profileStore', {
 					},
 				});
 
-				const resp = data.value as IUser;
+				const resp = data.value;
 
 				this.user = resp;
 				const companyURL = resp.organizations_url;
 
-				const { data: companyData } = await useFetchAPI(
-					companyURL,
-					{
+				const { data: companyData } =
+					await useFetchAPI(companyURL, {
 						headers: {
 							Accept: 'application/vnd.github+json',
 						},
-					}
-				);
+					});
 
-				const orgs = companyData.value as IUserOrg[];
+				const orgs = companyData.value;
 
 				this.user = {
 					...this.user,
@@ -48,7 +46,7 @@ export const useProfileStore = defineStore('profileStore', {
 					throw error;
 				}
 
-				throw new Error('Error fetching user top repos');
+				throw new Error('Error fetching user profile');
 			}
 		},
 		async getAuthUser() {
@@ -60,7 +58,7 @@ export const useProfileStore = defineStore('profileStore', {
 					},
 				});
 
-				const user = data.value as { login: string; avatar_url: string | null };
+				const user = data.value;
 				this.login = user.login;
 				this.avatar_url = user.avatar_url;
 				this.getProfile();
@@ -69,7 +67,7 @@ export const useProfileStore = defineStore('profileStore', {
 					throw error;
 				}
 
-				throw new Error('Error fetching user top repos');
+				throw new Error('Error fetching authenticated user');
 			}
 		},
 	},

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -1,0 +1,57 @@
+import useFetchAPI from "~~/hooks/useFetchApI";
+import { IUserApiResponse } from "~~/types/users/interface";
+
+export interface IProfileRootState {
+	user: IUserApiResponse | null;
+	login: string | null;
+	avatar_url: string | null;
+}
+
+export const useProfileStore = defineStore('profileStore', {
+	state: (): IProfileRootState => ({
+		user: null,
+		login: null,
+		avatar_url: null,
+	}),
+	actions: {
+		async getProfile() {
+			try {
+				const url = `/users/${this.login}`;
+				const { data } = await useFetchAPI(url, {
+					headers: {
+						Accept: 'application/vnd.github+json',
+					},
+				});
+
+				this.user = data.value as IUserApiResponse;
+			} catch (error: any) {
+				if (error && error?.response) {
+					throw error;
+				}
+
+				throw new Error('Error fetching user top repos');
+			}
+		},
+		async getAuthUser() {
+			try {
+				const url = `/user`;
+				const { data } = await useFetchAPI(url, {
+					headers: {
+						Accept: 'application/vnd.github+json',
+					},
+				});
+
+				const user = data.value as { login: string; avatar_url: string | null };
+				this.login = user.login;
+				this.avatar_url = user.avatar_url;
+				this.getProfile();
+			} catch (error: any) {
+				if (error && error?.response) {
+					throw error;
+				}
+
+				throw new Error('Error fetching user top repos');
+			}
+		},
+	},
+});

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -1,5 +1,5 @@
 import useFetchAPI from '~~/hooks/useFetchApI';
-import { IUser } from '~~/types/users/interface';
+import { IUser, IUserOrg } from '~~/types/users/interface';
 
 export interface IProfileRootState {
 	user: IUser | Record<string, any> | null;
@@ -29,7 +29,7 @@ export const useProfileStore = defineStore('profileStore', {
 				const companyURL = resp.organizations_url;
 
 				const { data: companyData } =
-					await useFetchAPI(companyURL, {
+					await useFetchAPI<IUserOrg>(companyURL, {
 						headers: {
 							Accept: 'application/vnd.github+json',
 						},
@@ -48,7 +48,7 @@ export const useProfileStore = defineStore('profileStore', {
 		async getAuthUser() {
 			try {
 				const url = `/user`;
-				const { data } = await useFetchAPI(url, {
+				const { data } = await useFetchAPI<IUser>(url, {
 					headers: {
 						Accept: 'application/vnd.github+json',
 					},

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -28,12 +28,11 @@ export const useProfileStore = defineStore('profileStore', {
 				this.user = resp;
 				const companyURL = resp.organizations_url;
 
-				const { data: companyData } =
-					await useFetchAPI<IUserOrg>(companyURL, {
-						headers: {
-							Accept: 'application/vnd.github+json',
-						},
-					});
+				const { data: companyData } = await useFetchAPI<IUserOrg>(companyURL, {
+					headers: {
+						Accept: 'application/vnd.github+json',
+					},
+				});
 
 				const orgs = companyData.value;
 

--- a/nuxt3-pinia-vuetify/store/profileStore.ts
+++ b/nuxt3-pinia-vuetify/store/profileStore.ts
@@ -41,11 +41,7 @@ export const useProfileStore = defineStore('profileStore', {
 					...this.user,
 					orgs,
 				};
-			} catch (error: any) {
-				if (error && error?.response) {
-					throw error;
-				}
-
+			} catch (error) {
 				throw new Error('Error fetching user profile');
 			}
 		},
@@ -62,11 +58,7 @@ export const useProfileStore = defineStore('profileStore', {
 				this.login = user.login;
 				this.avatar_url = user.avatar_url;
 				this.getProfile();
-			} catch (error: any) {
-				if (error && error?.response) {
-					throw error;
-				}
-
+			} catch (error) {
 				throw new Error('Error fetching authenticated user');
 			}
 		},

--- a/nuxt3-pinia-vuetify/types/users/interface.ts
+++ b/nuxt3-pinia-vuetify/types/users/interface.ts
@@ -1,3 +1,23 @@
+export interface IUserOrg {
+	login: string;
+	id: number;
+	node_id: string;
+	url: string;
+	repos_url: string;
+	events_url: string;
+	hooks_url: string;
+	issues_url: string;
+	members_url: string;
+	public_members_url: string;
+	avatar_url: string;
+	description: string;
+}
+
+export interface IUserStar {
+	name: string;
+	url: string;
+}
+
 export interface IUserApiResponse {
 	login: string;
 	id: number;
@@ -31,4 +51,9 @@ export interface IUserApiResponse {
 	following: number;
 	created_at: string;
 	updated_at: string;
+}
+
+export interface IUser extends IUserApiResponse {
+	orgs?: IUserOrg[];
+	stars?: IUserStar[];
 }

--- a/nuxt3-pinia-vuetify/types/users/interface.ts
+++ b/nuxt3-pinia-vuetify/types/users/interface.ts
@@ -1,0 +1,34 @@
+export interface IUserApiResponse {
+	login: string;
+	id: number;
+	node_id: string;
+	avatar_url: string;
+	gravatar_id: string;
+	url: string;
+	html_url: string;
+	followers_url: string;
+	following_url: string;
+	gists_url: string;
+	starred_url: string;
+	subscriptions_url: string;
+	organizations_url: string;
+	repos_url: string;
+	events_url: string;
+	received_events_url: string;
+	type: string;
+	site_admin: boolean;
+	name: string;
+	company: string;
+	blog: string;
+	location: string;
+	email: string;
+	hireable: boolean;
+	bio: string;
+	twitter_username: string;
+	public_repos: number;
+	public_gists: number;
+	followers: number;
+	following: number;
+	created_at: string;
+	updated_at: string;
+}


### PR DESCRIPTION
## Background

For the profile page, we want to fairly closely resemble the GitHub user page. This section is focused on the user “card”, where you can see profile information about the user.

## Acceptance

- [x] Get user info from GitHub API
- [x] For display on profile page; data needed:
    - [x] Photo
    - [x] Name (display name)
    - [x] username (login name)
    - [x] description
    - [x] followers
    - [x] following
    - [x] stars
    - [x] company info
    - [x] location info
    - [x] blog link
    - [x] organizations (need name and avatar)

