### PR TITLE
get org repos

### DIFF
--- a/nuxt3-pinia-vuetify/store/orgStore.ts
+++ b/nuxt3-pinia-vuetify/store/orgStore.ts
@@ -1,0 +1,30 @@
+import useFetchAPI from '~~/hooks/useFetchApI';
+import { IRepository } from '~~/types/interfaces';
+
+interface IOrgRootState {
+	repos: IRepository[];
+}
+
+export const useOrgStore = defineStore('orgStore ', {
+	state: (): IOrgRootState => ({
+		repos: [],
+	}),
+	actions: {
+		async getOrgRepos(org: string) {
+			try {
+				const url = `/orgs/${org}/repos`;
+
+				const { data } = await useFetchAPI<IRepository[]>(url, {
+					params: {
+						sort: 'updated',
+						per_page: '10',
+					},
+				});
+
+				this.repos = data.value;
+			} catch (error: any) {
+				throw new Error('Error fetching org repos');
+			}
+		},
+	},
+});


### PR DESCRIPTION
## Background

There will be a view for an organization’s profile, which, similar to the user’s profile, will list all of the organization’s repositories.

## Acceptance

- [x] Get organization repositories from GitHub API
- [x] For display on organization page; data needed:
    - [x] Repo name
    - [x] description
    - [x] language
    - [x] star count
    - [x] fork count
    - [x] last updated
    - [x] visibility tag

## Notes

- This query should start sorted by most recently updated.