### PR TITLE
single repo info

### DIFF
--- a/nuxt3-pinia-vuetify/store/repoStore.ts
+++ b/nuxt3-pinia-vuetify/store/repoStore.ts
@@ -1,0 +1,76 @@
+import useFetchAPI from '~~/hooks/useFetchApI';
+import { IRepository } from '~~/types/interfaces';
+import {
+	IRepositoryInfo,
+	IBranch,
+	IPullRequest,
+	IRepoContents,
+	IReadme,
+} from '~~/types/repository/interface';
+
+interface IRepoRootState {
+	repository: IRepositoryInfo | null;
+}
+
+export const useRepoStore = defineStore('repositoryStore ', {
+	state: (): IRepoRootState => ({
+		repository: null,
+	}),
+	actions: {
+		async getRepoInfo(owner: string, repoName: string) {
+			try {
+				// Define all the urls
+				const url = `/repos/${owner}/${repoName}`;
+				const branchesUrl = `${url}/branches`;
+				const pullRequestsUrl = `${url}/pulls`;
+				const repoContentsUrl = `${url}/contents`;
+				const repoReadmeUrl = `${url}/readme`;
+
+				// Prepare the promises to be fetched
+				const getRepoInfo = useFetchAPI<IRepository>(url);
+				const getRepoBranches = useFetchAPI<IBranch[]>(branchesUrl);
+				const getPullRequests = useFetchAPI<IPullRequest[]>(pullRequestsUrl, {
+					params: {
+						state: 'all',
+					},
+				});
+				const getRepoRootContents =
+					useFetchAPI<IRepoContents[]>(repoContentsUrl);
+				const getRepoReadme = useFetchAPI<IReadme>(repoReadmeUrl);
+
+				// Fetch all the data
+				const [
+					{ data: repoInfo },
+					{ data: repoBranches },
+					{ data: repoPullRequests },
+					{ data: repoRootContent },
+					{ data: repoReadme },
+				] = await Promise.all([
+					getRepoInfo,
+					getRepoBranches,
+					getPullRequests,
+					getRepoRootContents,
+					getRepoReadme,
+				]);
+
+				this.repository = {
+					owner: repoInfo.owner.login,
+					name: repoInfo.name,
+					visibility: repoInfo.visibility,
+					watchersCount: repoInfo.watchers_count,
+					stargazersCount: repoInfo.stargazers_count,
+					forksCount: repoInfo.forks_count,
+					openIssuesCount: repoInfo.open_issues_count,
+					description: repoInfo.description,
+					url: repoInfo.url,
+					branches: repoBranches,
+					pullsRequests: repoPullRequests,
+					rootContent: repoRootContent,
+					readme: repoReadme,
+				};
+			} catch (error: any) {
+				throw new Error('Error fetching repository info');
+			}
+		},
+	},
+});

--- a/nuxt3-pinia-vuetify/types/repository/enums.ts
+++ b/nuxt3-pinia-vuetify/types/repository/enums.ts
@@ -1,0 +1,26 @@
+export enum StateEnum {
+	OPEN = 'open',
+	CLOSED = 'closed',
+	MERGED = 'merged',
+}
+
+export enum IssueStateEnum {
+	OPEN = 'open',
+	CLOSED = 'closed',
+}
+
+export enum SortEnum {
+	CREATED = 'created',
+	UPDATED = 'updated',
+	COMMENTS = 'comments',
+}
+
+export enum DirectionEnum {
+	ASC = 'asc',
+	DESC = 'desc',
+}
+
+export enum IssueTypeEnum {
+	ISSUE = 'issue',
+	PULL_REQUEST = 'pr',
+}

--- a/nuxt3-pinia-vuetify/types/repository/interface.ts
+++ b/nuxt3-pinia-vuetify/types/repository/interface.ts
@@ -1,29 +1,6 @@
 import { IUser } from '../users/interface';
 import { StateEnum, SortEnum, DirectionEnum } from './enums';
 
-export interface IRepository {
-	id: number;
-	name: string;
-	full_name: string;
-	owner: { login: string };
-	description: string;
-	private: boolean;
-	html_url: string;
-	url: string;
-	updated_at: Date;
-	stargazers_count: number;
-	language: string;
-	branches_url: string;
-	visibility: 'public' | 'private';
-	subscribers_count: number;
-	forks_count: number;
-	open_issues_count: number;
-	pulls: number;
-	default_branch: string;
-	homepage: string;
-	watchers_count: number;
-}
-
 export interface IPullRequest {
 	title: string;
 	number: string;

--- a/nuxt3-pinia-vuetify/types/repository/interface.ts
+++ b/nuxt3-pinia-vuetify/types/repository/interface.ts
@@ -1,0 +1,130 @@
+import { IUser } from '../users/interface';
+import { StateEnum, SortEnum, DirectionEnum } from './enums';
+
+export interface IRepository {
+	id: number;
+	name: string;
+	full_name: string;
+	owner: { login: string };
+	description: string;
+	private: boolean;
+	html_url: string;
+	url: string;
+	updated_at: Date;
+	stargazers_count: number;
+	language: string;
+	branches_url: string;
+	visibility: 'public' | 'private';
+	subscribers_count: number;
+	forks_count: number;
+	open_issues_count: number;
+	pulls: number;
+	default_branch: string;
+	homepage: string;
+	watchers_count: number;
+}
+
+export interface IPullRequest {
+	title: string;
+	number: string;
+	created_at: string;
+	user: {
+		login: string;
+	};
+	state: StateEnum;
+	messageCount: number;
+	isMerged?: boolean;
+	merged_at: string | null;
+	review_comments_url: string;
+	comments: any;
+}
+
+export interface IRepoContents {
+	name: string;
+	type: string;
+	path: string;
+}
+
+export interface IBranch {
+	name: string;
+	commit: {
+		sha: string;
+		url: string;
+	};
+	protected: boolean;
+}
+
+export interface IReadme {
+	name: string;
+	path: string;
+	sha: string;
+	size: number;
+	url: string;
+	html_url: string;
+	git_url: string;
+	download_url: string;
+	type: string;
+	content: string;
+	encoding: string;
+	_links: {
+		self: string;
+		git: string;
+		html: string;
+	};
+}
+
+export interface IRepositoryIssuesApiParams {
+	milestone?: string;
+	state?: StateEnum;
+	assignee?: string;
+	creator?: string;
+	mentioned?: string;
+	labels?: string;
+	sort?: SortEnum;
+	direction?: DirectionEnum;
+	since?: string;
+	per_page?: number;
+	page?: number;
+}
+
+export interface IIssueLabel {
+	name: string;
+	description: string;
+	color: string;
+	default: boolean;
+}
+
+export interface IIssue {
+	number: number;
+	state: string;
+	title: string;
+	body: string;
+	user: Partial<IUser>;
+	labels: IIssueLabel[];
+	assignee: Partial<IUser>;
+	assignees: Partial<IUser>[];
+	locked: boolean;
+	active_lock_reason: string;
+	comments: number;
+	closed_at?: string;
+	created_at: string;
+	updated_at: string;
+	closed_by: Partial<IUser>;
+}
+
+export interface IRepositoryInfo {
+	owner: string;
+	name: string;
+	visibility: string;
+	watchersCount: number;
+	stargazersCount: number;
+	forksCount: number;
+	openIssuesCount: number;
+	description: string;
+	url: string;
+	branches: IBranch[];
+	readme: IReadme | null;
+	rootContent: IRepoContents[];
+	pullsRequests: IPullRequest[];
+	issues?: IIssue[];
+}


### PR DESCRIPTION
## Background

We want to create a view for an individual repository. It will share a similar look to the same page on GitHub, but with slightly fewer features.

## Acceptance

- [x] Get single repository information from GitHub API
- [x] For display on single repository page; data needed:
    - [x] username 
    - [x] repo name
    - [x] visibility badge (public / private)
    - [x] watch count
    - [x] star count
    - [x] fork count
    - [x] issue count
    - [x] pull request count
    - [x] branch names
    - [x] about description
    - [x] about website link (if available)
    - [x] root tree information (folders and files)
    - [x] readme information

