### PR TITLE
chore: update node versions of build actions

### DIFF
--- a/.github/workflows/ci-angular-apollo-tailwind.yml
+++ b/.github/workflows/ci-angular-apollo-tailwind.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-angular-ngrx-scss.yml
+++ b/.github/workflows/ci-angular-ngrx-scss.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-cra-rxjs-styled-components.yml
+++ b/.github/workflows/ci-cra-rxjs-styled-components.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-nuxt-pinia-tailwind.yml
+++ b/.github/workflows/ci-nuxt-pinia-tailwind.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-qwik-graphql-tailwind.yml
+++ b/.github/workflows/ci-qwik-graphql-tailwind.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-solidjs-tailwind.yml
+++ b/.github/workflows/ci-solidjs-tailwind.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-solidstart-tanstackquery-tailwind-modules.yml
+++ b/.github/workflows/ci-solidstart-tanstackquery-tailwind-modules.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-svelte-kit-scss.yml
+++ b/.github/workflows/ci-svelte-kit-scss.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-vue3-apollo-quasar.yml
+++ b/.github/workflows/ci-vue3-apollo-quasar.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/expo-zustand-styled-components.yml
+++ b/.github/workflows/expo-zustand-styled-components.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/remix-deploy.yml
+++ b/.github/workflows/remix-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: 📥 Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

Node 14 is being deprecated on August 15th 2023 and Angular 16 no longer supports it. The current Node LTS is 18. Therefore I have updated our build actions to no longer use Node 14 and use 16 and/or 18 instead.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev-github-showcases/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1889
- [x] I have verified this change works and introduces no additional issues to the best of my knowledge
