### PR TITLE
chore: milestone works for only issues

### DIFF
--- a/solidjs-tailwind/src/components/AuthGuard/AuthGuard.spec.jsx
+++ b/solidjs-tailwind/src/components/AuthGuard/AuthGuard.spec.jsx
@@ -5,8 +5,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import 'whatwg-fetch';
 import AuthGuard from './AuthGuard';
 
-
-window.scrollTo = vi.fn()
+window.scrollTo = vi.fn();
 
 vi.mock('../../auth', () => {
   return {

--- a/solidjs-tailwind/src/components/PRAndIssuesHeader/PRAndIssuesHeader.jsx
+++ b/solidjs-tailwind/src/components/PRAndIssuesHeader/PRAndIssuesHeader.jsx
@@ -4,7 +4,7 @@ import FilterDropdown from '../FilterDropDown/FilterDropdown';
 import { SORT_OPTIONS } from '../../utils/constants';
 import { createMemo } from 'solid-js';
 import { usePrAndIssuesContext } from '../../contexts/PrAndIssuesContext';
-import { getSelectedMilestoneId } from './utils';
+import { getSelectedMilestoneNumber } from './utils';
 
 const PRAndIssuesHeader = (props) => {
   const {
@@ -19,7 +19,7 @@ const PRAndIssuesHeader = (props) => {
     setSelectedMilestone,
     selectedMilestone,
     milestoneOpt,
-    setMilestoneId,
+    setMilestoneNumber,
   } = usePrAndIssuesContext();
 
   const sortOptions = Object.values(SORT_OPTIONS);
@@ -35,7 +35,9 @@ const PRAndIssuesHeader = (props) => {
     setSelectedLabel(selectedLabel() !== value ? value : undefined);
   const selectMilestone = (value) => {
     setSelectedMilestone(selectedMilestone() !== value ? value : undefined);
-    setMilestoneId(getSelectedMilestoneId(milestoneOpt(), selectedMilestone()));
+    setMilestoneNumber(
+      getSelectedMilestoneNumber(milestoneOpt(), selectedMilestone())
+    );
   };
 
   return (

--- a/solidjs-tailwind/src/components/PRAndIssuesHeader/utils.jsx
+++ b/solidjs-tailwind/src/components/PRAndIssuesHeader/utils.jsx
@@ -1,4 +1,9 @@
-export const getSelectedMilestoneId = (milestoneOptions, selectedMilestone) =>
+export const getSelectedMilestoneNumber = (
+  milestoneOptions,
   selectedMilestone
-    ? milestoneOptions.filter((mo) => mo.title === selectedMilestone)[0].id
+) =>
+  selectedMilestone
+    ? milestoneOptions
+        .filter((mo) => mo.title === selectedMilestone)[0]
+        .number.toString()
     : undefined;

--- a/solidjs-tailwind/src/components/RepoIssues/RepoIssues.jsx
+++ b/solidjs-tailwind/src/components/RepoIssues/RepoIssues.jsx
@@ -74,7 +74,9 @@ const RepoIssues = () => {
   return (
     <div class="md:py-12 max-w-screen-xl mx-auto">
       <Show when={!repo.loading} fallback={<PRAndIssueLoaderSkeleton />}>
-        <Show when={selectedLabel() || sortBy() !== 'Newest'}>
+        <Show
+          when={selectedLabel() || sortBy() !== 'Newest' || milestoneNumber()}
+        >
           <button
             type="button"
             class="flex items-center gap-2 text-sm my-4 ml-2 cursor-pointer"

--- a/solidjs-tailwind/src/components/RepoIssues/RepoIssues.jsx
+++ b/solidjs-tailwind/src/components/RepoIssues/RepoIssues.jsx
@@ -22,7 +22,7 @@ const RepoIssues = () => {
     setMilestoneOpt,
     clearSortAndFilter,
     selectedMilestone,
-    milestoneId,
+    milestoneNumber,
   } = usePrAndIssuesContext();
 
   const fetchParameters = () => ({
@@ -32,7 +32,7 @@ const RepoIssues = () => {
     direction: parseSortParams(SORT_OPTIONS, sortBy(), 1),
     filterBy: {
       labels: selectedLabel() ? [selectedLabel()] : undefined,
-      milestone: selectedMilestone() ? milestoneId() : undefined,
+      milestoneNumber: selectedMilestone() ? milestoneNumber() : undefined,
     },
     before: query.before,
     after: query.after,

--- a/solidjs-tailwind/src/components/RepoPullRequests/RepoPullRequests.jsx
+++ b/solidjs-tailwind/src/components/RepoPullRequests/RepoPullRequests.jsx
@@ -12,8 +12,17 @@ import { PRAndIssueLoaderSkeleton } from '../PRAndIssueLoaderSkeleton';
 const RepoPullRequests = () => {
   const params = useParams();
   const location = useLocation();
-  const { tabActive, sortBy, selectedLabel, setLabelOpt, clearSortAndFilter } =
-    usePrAndIssuesContext();
+  const {
+    tabActive,
+    sortBy,
+    milestoneOpt,
+    labelOpt,
+    selectedLabel,
+    setLabelOpt,
+    setMilestoneOpt,
+    clearSortAndFilter,
+    selectedMilestone,
+  } = usePrAndIssuesContext();
 
   const [data, setData] = createSignal([]);
   const [openCount, setOpenCount] = createSignal();
@@ -26,6 +35,7 @@ const RepoPullRequests = () => {
     orderBy: parseSortParams(SORT_OPTIONS, sortBy(), 0),
     direction: parseSortParams(SORT_OPTIONS, sortBy(), 1),
     labels: selectedLabel() ? [selectedLabel()] : undefined,
+    milestone: selectedMilestone(),
     before:
       typeof location.query.before === 'string'
         ? location.query.before
@@ -47,7 +57,8 @@ const RepoPullRequests = () => {
 
   createEffect(() => {
     if (resp() && !resp.loading) {
-      setLabelOpt(resp().labels);
+      setLabelOpt(resp().labels || labelOpt());
+      setMilestoneOpt(resp().milestones || milestoneOpt());
       setOpenCount(resp().openPullRequests.totalCount);
       setClosedCount(resp().closedPullRequests.totalCount);
       setPageInfo(
@@ -69,7 +80,9 @@ const RepoPullRequests = () => {
         <PRAndIssueLoaderSkeleton />
       ) : (
         <>
-          {(selectedLabel() || sortBy() !== 'Newest') && (
+          {(selectedLabel() ||
+            selectedMilestone() ||
+            sortBy() !== 'Newest') && (
             <div
               class="flex items-center gap-2 text-sm my-4 ml-2 cursor-pointer"
               onClick={clearSortAndFilter}

--- a/solidjs-tailwind/src/contexts/PrAndIssuesContext.jsx
+++ b/solidjs-tailwind/src/contexts/PrAndIssuesContext.jsx
@@ -16,12 +16,13 @@ export function PrAndIssuesProvider(props) {
   const [selectedMilestone, setSelectedMilestone] = createSignal(undefined);
   const [labelOpt, setLabelOpt] = createSignal([]);
   const [milestoneOpt, setMilestoneOpt] = createSignal([]);
-  const [milestoneId, setMilestoneId] = createSignal(undefined);
+  const [milestoneNumber, setMilestoneNumber] = createSignal(undefined);
 
   const clearSortAndFilter = () => {
     setSortBy('Newest');
     setSelectedLabel(undefined);
     setSelectedMilestone(undefined);
+    setMilestoneNumber(undefined);
   };
 
   const PrAndIssuesParameters = {
@@ -39,8 +40,8 @@ export function PrAndIssuesProvider(props) {
     setSelectedMilestone,
     milestoneOpt,
     setMilestoneOpt,
-    milestoneId,
-    setMilestoneId,
+    milestoneNumber,
+    setMilestoneNumber,
   };
 
   return (

--- a/solidjs-tailwind/src/services/api.js
+++ b/solidjs-tailwind/src/services/api.js
@@ -7,7 +7,7 @@ const FetchApi = async ({ url, query, variables, headersOptions }) => {
         'Content-Type': 'application/json',
       },
     };
-    if (query && variables) {
+    if (query) {
       fetchObj = {
         ...fetchObj,
         method: 'POST',

--- a/solidjs-tailwind/src/services/api.js
+++ b/solidjs-tailwind/src/services/api.js
@@ -1,17 +1,23 @@
 const FetchApi = async ({ url, query, variables, headersOptions }) => {
   return await new Promise((resolve, reject) => {
-    fetch(url, {
-      method: 'POST',
+    let fetchObj = {
       headers: {
         ...headersOptions,
         Accept: 'application/vnd.github+json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        query,
-        variables,
-      }),
-    })
+    };
+    if (query && variables) {
+      fetchObj = {
+        ...fetchObj,
+        method: 'POST',
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      };
+    }
+    fetch(url, fetchObj)
       .then((res) => res.json())
       .then((result) => {
         resolve(result);

--- a/solidjs-tailwind/src/services/get-issues.js
+++ b/solidjs-tailwind/src/services/get-issues.js
@@ -2,6 +2,7 @@ import FetchApi from './api';
 import { useAuth } from '../auth';
 import { ISSUES_QUERY } from './queries/issue-info';
 import { GITHUB_GRAPHQL } from '../utils/constants';
+import { parseLabels, parseMilestones } from '../utils/parseFunctions';
 
 function parseIssues(connection) {
   if (!connection) {
@@ -56,43 +57,6 @@ function parseIssues(connection) {
   }, []);
 
   return { issues, totalCount, pageInfo };
-}
-
-function parseMilestones(milestones) {
-  const nodes = milestones?.nodes || [];
-  return nodes.reduce((milestones, milestone) => {
-    if (!milestone) {
-      return milestones;
-    }
-
-    return [
-      ...milestones,
-      {
-        id: milestone.id,
-        closed: milestone.closed,
-        title: milestone.title,
-        number: milestone.number,
-        description: milestone.description,
-      },
-    ];
-  }, []);
-}
-
-function parseLabels(labels) {
-  const nodes = labels?.nodes || [];
-  return nodes.reduce((labels, label) => {
-    if (!label) {
-      return labels;
-    }
-
-    return [
-      ...labels,
-      {
-        color: label.color,
-        name: label.name,
-      },
-    ];
-  }, []);
 }
 
 const getIssues = async ({

--- a/solidjs-tailwind/src/services/get-repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/get-repo-pull-requests.js
@@ -108,11 +108,6 @@ const getRepoPullRequests = async ({
     },
   };
 
-  let openPullRequests;
-  let closedPullRequests;
-  let milestones;
-  let labelMap;
-
   if (milestone) {
     //Using REST API for filters involving milestone as filter by milestone isn't supported on the Graphql
     const pulls_data = {
@@ -144,27 +139,34 @@ const getRepoPullRequests = async ({
       },
     });
 
-    openPullRequests = parseRestAPIPullRequests(restOpenPullRequests);
-    closedPullRequests = parseRestAPIPullRequests(restClosedPullRequests);
+    const openPullRequests = parseRestAPIPullRequests(restOpenPullRequests);
+    const closedPullRequests = parseRestAPIPullRequests(restClosedPullRequests);
+
+    return {
+      openPullRequests,
+      closedPullRequests,
+    };
   } else {
     const resp = await FetchApi(data);
-    openPullRequests = parsePullRequests(resp.data.repository?.openPullRequest);
+    const openPullRequests = parsePullRequests(
+      resp.data.repository?.openPullRequest
+    );
 
-    closedPullRequests = parsePullRequests(
+    const closedPullRequests = parsePullRequests(
       resp.data.repository?.closedPullRequest
     );
 
-    milestones = parseMilestones(resp.data.repository?.milestones);
+    const milestones = parseMilestones(resp.data.repository?.milestones);
 
-    labelMap = parseLabels(resp.data.repository?.labels);
+    const labelMap = parseLabels(resp.data.repository?.labels);
+
+    return {
+      openPullRequests,
+      closedPullRequests,
+      labels: labelMap,
+      milestones,
+    };
   }
-
-  return {
-    openPullRequests,
-    closedPullRequests,
-    labels: labelMap,
-    milestones,
-  };
 };
 
 export default getRepoPullRequests;

--- a/solidjs-tailwind/src/services/get-repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/get-repo-pull-requests.js
@@ -2,6 +2,7 @@ import { REPO_PULL_REQUESTS } from './queries/repo-pull-requests';
 import { useAuth } from '../auth';
 import FetchApi from './api';
 import { GITHUB_GRAPHQL } from '../utils/constants';
+import { parseLabels } from '../utils/parseFunctions';
 
 function parsePullRequests(connection) {
   if (!connection) {
@@ -58,23 +59,6 @@ function parsePullRequests(connection) {
   }, []);
 
   return { pullRequests, totalCount, pageInfo };
-}
-
-function parseLabels(labels) {
-  const nodes = labels?.nodes || [];
-  return nodes.reduce((labels, label) => {
-    if (!label) {
-      return labels;
-    }
-
-    return [
-      ...labels,
-      {
-        color: label.color,
-        name: label.name,
-      },
-    ];
-  }, []);
 }
 
 /**

--- a/solidjs-tailwind/src/services/queries/repo-pull-requests.js
+++ b/solidjs-tailwind/src/services/queries/repo-pull-requests.js
@@ -1,6 +1,22 @@
 export const REPO_PULL_REQUESTS = `
   query PullRequests($owner: String!, $name: String!, $first: Int, $last: Int, $before: String, $after: String, $labels: [String!], $orderBy: IssueOrderField!, $direction: OrderDirection!) {
     repository(owner: $owner, name: $name) {
+       milestones(first: 100, states: [OPEN]) {
+        nodes {
+          id
+          closed
+          description
+          number
+          title
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        totalCount
+      }
       labels(first: 100) {
         totalCount
         nodes {

--- a/solidjs-tailwind/src/utils/constants.js
+++ b/solidjs-tailwind/src/utils/constants.js
@@ -18,6 +18,15 @@ export const OrderField = {
   UpdatedAt: 'UPDATED_AT',
 };
 
+const OrderFieldRest = {
+  /** Order issues by comment count */
+  COMMENTS: 'comments',
+  /** Order issues by creation time */
+  CREATED_AT: 'created',
+  /** Order issues by update time */
+  UPDATED_AT: 'updated',
+};
+
 export const OrderDirection = {
   Asc: 'ASC',
   Desc: 'DESC',
@@ -33,3 +42,43 @@ export const SORT_OPTIONS = {
 };
 
 export const DEFAULT_PAGE_SIZE = 30;
+
+export function convertObjectToQueryString(object) {
+  return new URLSearchParams(object).toString();
+}
+
+export function replaceSpaceWithPlus(str) {
+  return str.split(' ').join('+');
+}
+
+export const replaceEncodedSpaceWithPlus = (str) => {
+  return str.split(encodeURIComponent(' ')).join('+');
+};
+
+export const SEARCH_PULLS = ({
+  owner,
+  name,
+  first,
+  sort,
+  direction,
+  labels,
+  type,
+  milestone,
+  state,
+}) => {
+  const params = {
+    per_page: first,
+    sort: OrderFieldRest[sort],
+    order: direction.toLowerCase(),
+  };
+  const queryStrings = convertObjectToQueryString(params);
+  const milestone_check = `+milestone:"${
+    typeof milestone === 'string'
+      ? replaceEncodedSpaceWithPlus(encodeURIComponent(milestone))
+      : milestone
+  }"`;
+  const Q = `+is:${state}+is:${type}${
+    labels ? `+label:"${replaceSpaceWithPlus(labels)}"` : ''
+  }${milestone ? milestone_check : ''}`;
+  return `${GITHUB_URL_BASE}/search/issues?q=repo:${owner}/${name}${Q}&${queryStrings}`;
+};

--- a/solidjs-tailwind/src/utils/parseFunctions.js
+++ b/solidjs-tailwind/src/utils/parseFunctions.js
@@ -1,0 +1,36 @@
+export function parseLabels(labels) {
+  const nodes = labels?.nodes || [];
+  return nodes.reduce((labels, label) => {
+    if (!label) {
+      return labels;
+    }
+
+    return [
+      ...labels,
+      {
+        color: label.color,
+        name: label.name,
+      },
+    ];
+  }, []);
+}
+
+export function parseMilestones(milestones) {
+  const nodes = milestones?.nodes || [];
+  return nodes.reduce((milestones, milestone) => {
+    if (!milestone) {
+      return milestones;
+    }
+
+    return [
+      ...milestones,
+      {
+        id: milestone.id,
+        closed: milestone.closed,
+        title: milestone.title,
+        number: milestone.number,
+        description: milestone.description,
+      },
+    ];
+  }, []);
+}

--- a/solidjs-tailwind/src/utils/parseRestAPIPullRequest.js
+++ b/solidjs-tailwind/src/utils/parseRestAPIPullRequest.js
@@ -1,0 +1,59 @@
+export default function parseRestAPIPullRequests(connection) {
+  if (!connection) {
+    return {
+      pullRequests: [],
+      totalCount: 0,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    };
+  }
+
+  const pageInfo = {
+    hasNextPage: !connection.incomplete_results,
+    hasPreviousPage: connection.incomplete_results,
+  };
+  const nodes = connection.items || [];
+  const totalCount = connection.total_count;
+
+  const pullRequests = nodes.reduce((pullRequests, pullRequest) => {
+    if (!pullRequest) {
+      return pullRequests;
+    }
+
+    const labelNodes = pullRequest.labels || [];
+    const labels = labelNodes.reduce(
+      (labels, label) =>
+        label
+          ? [
+              ...labels,
+              {
+                color: label.color,
+                name: label.name,
+              },
+            ]
+          : labels,
+      []
+    );
+
+    return [
+      ...pullRequests,
+      {
+        id: pullRequest.id,
+        login: pullRequest.user?.login,
+        commentCount: pullRequest.comments,
+        labelCount: pullRequest.labels.length,
+        labels,
+        closed: Boolean(pullRequest.closed_at),
+        merged: Boolean(pullRequest.merged_at),
+        title: pullRequest.title,
+        number: pullRequest.number,
+        createdAt: pullRequest.created_at,
+        closedAt: pullRequest.closed_at,
+        mergedAt: pullRequest.merged_at,
+        state: pullRequest.state.toUpperCase(),
+        url: pullRequest.url,
+      },
+    ];
+  }, []);
+
+  return { pullRequests, totalCount, pageInfo };
+}


### PR DESCRIPTION
## Summary of change
was able to make milestone work for the Issues tab but apparently, we can't filter by milestones for pull requests with the Graphql API, so we used REST API to achieve the milestone filter functionality

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev-github-showcases/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1944 
- [x] I have verified this change works and introduces no additional issues to the best of my knowledge

Issue Tab
https://www.awesomescreenshot.com/video/20111107?key=03f2a8c5ec849e5d843422e4e6bffb90

Pull requests Tab
https://www.awesomescreenshot.com/video/20133828?key=53b25f598262c011b0f566a81815ca95